### PR TITLE
Create finance screen with functional components

### DIFF
--- a/app/finanzas.tsx
+++ b/app/finanzas.tsx
@@ -1,0 +1,73 @@
+import { useState } from 'react';
+import { ScrollView, View, Text, StyleSheet, Pressable } from 'react-native';
+
+import IncomeSection, { Colors } from '@/components/finance/IncomeSection';
+import DebtSection from '@/components/finance/DebtSection';
+import ExpenseSection from '@/components/finance/ExpenseSection';
+import BalanceSummary from '@/components/finance/BalanceSummary';
+import BalanceChart from '@/components/finance/BalanceChart';
+import { useFinanzas } from '@/hooks/useFinanzas';
+
+const lightColors: Colors = {
+  bg: '#f4f4f4',
+  text: '#222',
+  surface: '#ffffff',
+  primary: '#004388',
+  accent: '#00acac',
+};
+
+const darkColors: Colors = {
+  bg: '#1e1e1e',
+  text: '#f4f4f4',
+  surface: '#2c2c2c',
+  primary: '#00acac',
+  accent: '#8ec89a',
+};
+
+export default function FinanzasScreen() {
+  const [theme, setTheme] = useState<'light' | 'dark'>('dark');
+  const colors = theme === 'dark' ? darkColors : lightColors;
+  const finance = useFinanzas();
+
+  return (
+    <ScrollView style={[styles.container, { backgroundColor: colors.bg }]}>
+      <View style={[styles.header, { backgroundColor: colors.primary }]}>
+        <Text style={[styles.headerText, { color: '#fff' }]}>Mis Finanzas Personales</Text>
+        <Pressable onPress={() => setTheme(theme === 'dark' ? 'light' : 'dark')}> 
+          <Text style={styles.toggle}>🌓</Text>
+        </Pressable>
+      </View>
+      <View style={styles.content}>
+        <IncomeSection ingresos={finance.ingresos} onAdd={finance.agregarIngreso} colors={colors} />
+        <DebtSection deudas={finance.deudas} onAdd={finance.agregarDeuda} colors={colors} />
+        <ExpenseSection gastos={finance.gastos} onAdd={finance.agregarGasto} colors={colors} />
+        <BalanceSummary balance={finance.balance} colors={colors} />
+        <BalanceChart ingresos={finance.ingresoTotal} deudas={finance.deudaTotal} gastos={finance.gastoTotal} colors={colors} />
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  header: {
+    padding: 16,
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  headerText: {
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+  toggle: {
+    marginLeft: 8,
+    fontSize: 18,
+    color: '#fff',
+  },
+  content: {
+    padding: 16,
+  },
+});

--- a/components/finance/BalanceChart.tsx
+++ b/components/finance/BalanceChart.tsx
@@ -1,0 +1,35 @@
+import { View, Text, StyleSheet } from 'react-native';
+
+import type { Colors } from './IncomeSection';
+
+interface Props {
+  ingresos: number;
+  deudas: number;
+  gastos: number;
+  colors: Colors;
+}
+
+export default function BalanceChart({ ingresos, deudas, gastos, colors }: Props) {
+  // Placeholder for a chart library
+  return (
+    <View style={[styles.container, { backgroundColor: colors.surface }]}>
+      <Text style={[styles.text, { color: colors.text }]}>Grafico</Text>
+      <Text style={{ color: colors.text }}>Ingresos: {ingresos}</Text>
+      <Text style={{ color: colors.text }}>Deudas: {deudas}</Text>
+      <Text style={{ color: colors.text }}>Gastos: {gastos}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    borderRadius: 8,
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  text: {
+    fontWeight: 'bold',
+    marginBottom: 8,
+  },
+});

--- a/components/finance/BalanceSummary.tsx
+++ b/components/finance/BalanceSummary.tsx
@@ -1,0 +1,29 @@
+import { View, Text, StyleSheet } from 'react-native';
+
+import type { Colors } from './IncomeSection';
+
+interface Props {
+  balance: number;
+  colors: Colors;
+}
+
+export default function BalanceSummary({ balance, colors }: Props) {
+  return (
+    <View style={[styles.container, { backgroundColor: colors.surface }]}>
+      <Text style={[styles.balance, { color: colors.text }]}>Saldo disponible: ${balance.toFixed(2)}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    borderRadius: 8,
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  balance: {
+    fontWeight: 'bold',
+    fontSize: 20,
+  },
+});

--- a/components/finance/DebtSection.tsx
+++ b/components/finance/DebtSection.tsx
@@ -1,0 +1,104 @@
+import { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+
+import type { Deuda } from '@/hooks/useFinanzas';
+import type { Colors } from './IncomeSection';
+
+interface Props {
+  deudas: Deuda[];
+  onAdd: (deuda: Deuda) => void;
+  colors: Colors;
+}
+
+export default function DebtSection({ deudas, onAdd, colors }: Props) {
+  const [concepto, setConcepto] = useState('');
+  const [monto, setMonto] = useState('');
+  const [meses, setMeses] = useState('');
+  const [aumento, setAumento] = useState('0');
+
+  const handleAdd = () => {
+    const montoNum = parseFloat(monto);
+    const mesesNum = parseInt(meses, 10);
+    const aumentoNum = parseFloat(aumento);
+    if (!concepto || isNaN(montoNum) || isNaN(mesesNum)) return;
+    onAdd({ concepto, monto: montoNum, meses: mesesNum, aumento: isNaN(aumentoNum) ? 0 : aumentoNum });
+    setConcepto('');
+    setMonto('');
+    setMeses('');
+    setAumento('0');
+  };
+
+  return (
+    <View style={[styles.section, { backgroundColor: colors.surface }]}>
+      <Text style={[styles.title, { color: colors.text }]}>Deudas</Text>
+      <View style={styles.group}>
+        <Text style={{ color: colors.text }}>Concepto</Text>
+        <TextInput
+          value={concepto}
+          onChangeText={setConcepto}
+          style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
+        />
+      </View>
+      <View style={styles.group}>
+        <Text style={{ color: colors.text }}>Monto</Text>
+        <TextInput
+          value={monto}
+          onChangeText={setMonto}
+          keyboardType="numeric"
+          style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
+        />
+      </View>
+      <View style={styles.group}>
+        <Text style={{ color: colors.text }}>Meses</Text>
+        <TextInput
+          value={meses}
+          onChangeText={setMeses}
+          keyboardType="numeric"
+          style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
+        />
+      </View>
+      <View style={styles.group}>
+        <Text style={{ color: colors.text }}>Aumento % cada 3 meses</Text>
+        <TextInput
+          value={aumento}
+          onChangeText={setAumento}
+          keyboardType="numeric"
+          style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
+        />
+      </View>
+      <Button title="Agregar Deuda" color={colors.primary} onPress={handleAdd} />
+      <View style={styles.list}>
+        {deudas.map((d, idx) => (
+          <Text key={idx} style={{ color: colors.text }}>
+            - ${d.monto.toFixed(2)} ({d.concepto})
+          </Text>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: {
+    padding: 16,
+    borderRadius: 8,
+    marginBottom: 16,
+  },
+  title: {
+    fontWeight: 'bold',
+    fontSize: 18,
+    marginBottom: 8,
+  },
+  group: {
+    marginBottom: 12,
+  },
+  input: {
+    borderWidth: 1,
+    borderRadius: 6,
+    padding: 8,
+    marginTop: 4,
+  },
+  list: {
+    marginTop: 8,
+  },
+});

--- a/components/finance/ExpenseSection.tsx
+++ b/components/finance/ExpenseSection.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+
+import type { Gasto } from '@/hooks/useFinanzas';
+import type { Colors } from './IncomeSection';
+
+interface Props {
+  gastos: Gasto[];
+  onAdd: (gasto: Gasto) => void;
+  colors: Colors;
+}
+
+export default function ExpenseSection({ gastos, onAdd, colors }: Props) {
+  const [concepto, setConcepto] = useState('');
+  const [monto, setMonto] = useState('');
+
+  const handleAdd = () => {
+    const montoNum = parseFloat(monto);
+    if (!concepto || isNaN(montoNum)) return;
+    onAdd({ concepto, monto: montoNum });
+    setConcepto('');
+    setMonto('');
+  };
+
+  return (
+    <View style={[styles.section, { backgroundColor: colors.surface }]}>
+      <Text style={[styles.title, { color: colors.text }]}>Gastos Diarios</Text>
+      <View style={styles.group}>
+        <Text style={{ color: colors.text }}>Concepto</Text>
+        <TextInput
+          value={concepto}
+          onChangeText={setConcepto}
+          style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
+        />
+      </View>
+      <View style={styles.group}>
+        <Text style={{ color: colors.text }}>Monto</Text>
+        <TextInput
+          value={monto}
+          onChangeText={setMonto}
+          keyboardType="numeric"
+          style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
+        />
+      </View>
+      <Button title="Agregar Gasto" color={colors.primary} onPress={handleAdd} />
+      <View style={styles.list}>
+        {gastos.map((g, idx) => (
+          <Text key={idx} style={{ color: colors.text }}>
+            - ${g.monto.toFixed(2)} ({g.concepto})
+          </Text>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: {
+    padding: 16,
+    borderRadius: 8,
+    marginBottom: 16,
+  },
+  title: {
+    fontWeight: 'bold',
+    fontSize: 18,
+    marginBottom: 8,
+  },
+  group: {
+    marginBottom: 12,
+  },
+  input: {
+    borderWidth: 1,
+    borderRadius: 6,
+    padding: 8,
+    marginTop: 4,
+  },
+  list: {
+    marginTop: 8,
+  },
+});

--- a/components/finance/IncomeSection.tsx
+++ b/components/finance/IncomeSection.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+
+import type { Ingreso } from '@/hooks/useFinanzas';
+
+interface Props {
+  ingresos: Ingreso[];
+  onAdd: (ingreso: Ingreso) => void;
+  colors: Colors;
+}
+
+export interface Colors {
+  bg: string;
+  text: string;
+  surface: string;
+  primary: string;
+  accent: string;
+}
+
+export default function IncomeSection({ ingresos, onAdd, colors }: Props) {
+  const [concepto, setConcepto] = useState('');
+  const [monto, setMonto] = useState('');
+  const [meses, setMeses] = useState('0');
+
+  const handleAdd = () => {
+    const montoNum = parseFloat(monto);
+    const mesesNum = parseInt(meses, 10);
+    if (!concepto || isNaN(montoNum)) return;
+    onAdd({ concepto, monto: montoNum, meses: isNaN(mesesNum) ? 0 : mesesNum });
+    setConcepto('');
+    setMonto('');
+    setMeses('0');
+  };
+
+  return (
+    <View style={[styles.section, { backgroundColor: colors.surface }]}>
+      <Text style={[styles.title, { color: colors.text }]}>Ingresos</Text>
+      <View style={styles.group}>
+        <Text style={{ color: colors.text }}>Concepto</Text>
+        <TextInput
+          value={concepto}
+          onChangeText={setConcepto}
+          style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
+        />
+      </View>
+      <View style={styles.group}>
+        <Text style={{ color: colors.text }}>Monto</Text>
+        <TextInput
+          value={monto}
+          onChangeText={setMonto}
+          keyboardType="numeric"
+          style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
+        />
+      </View>
+      <View style={styles.group}>
+        <Text style={{ color: colors.text }}>Recurrente (meses)</Text>
+        <TextInput
+          value={meses}
+          onChangeText={setMeses}
+          keyboardType="numeric"
+          style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
+        />
+      </View>
+      <Button title="Agregar Ingreso" color={colors.primary} onPress={handleAdd} />
+      <View style={styles.list}>
+        {ingresos.map((i, idx) => (
+          <Text key={idx} style={{ color: colors.text }}>
+            + ${i.monto.toFixed(2)} ({i.concepto})
+          </Text>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: {
+    padding: 16,
+    borderRadius: 8,
+    marginBottom: 16,
+  },
+  title: {
+    fontWeight: 'bold',
+    fontSize: 18,
+    marginBottom: 8,
+  },
+  group: {
+    marginBottom: 12,
+  },
+  input: {
+    borderWidth: 1,
+    borderRadius: 6,
+    padding: 8,
+    marginTop: 4,
+  },
+  list: {
+    marginTop: 8,
+  },
+});

--- a/hooks/useFinanzas.ts
+++ b/hooks/useFinanzas.ts
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+
+export interface Ingreso {
+  concepto: string;
+  monto: number;
+  meses: number;
+}
+
+export interface Deuda {
+  concepto: string;
+  monto: number;
+  meses: number;
+  aumento: number;
+}
+
+export interface Gasto {
+  concepto: string;
+  monto: number;
+}
+
+export function useFinanzas() {
+  const [ingresos, setIngresos] = useState<Ingreso[]>([]);
+  const [deudas, setDeudas] = useState<Deuda[]>([]);
+  const [gastos, setGastos] = useState<Gasto[]>([]);
+
+  function agregarIngreso(ingreso: Ingreso) {
+    setIngresos((prev) => [...prev, ingreso]);
+  }
+
+  function agregarDeuda(deuda: Deuda) {
+    setDeudas((prev) => [...prev, deuda]);
+  }
+
+  function agregarGasto(gasto: Gasto) {
+    setGastos((prev) => [...prev, gasto]);
+  }
+
+  const ingresoTotal = ingresos.reduce((sum, i) => sum + i.monto, 0);
+  const deudaTotal = deudas.reduce((sum, d) => sum + d.monto, 0);
+  const gastoTotal = gastos.reduce((sum, g) => sum + g.monto, 0);
+  const balance = ingresoTotal - deudaTotal - gastoTotal;
+
+  return {
+    ingresos,
+    deudas,
+    gastos,
+    agregarIngreso,
+    agregarDeuda,
+    agregarGasto,
+    ingresoTotal,
+    deudaTotal,
+    gastoTotal,
+    balance,
+  };
+}


### PR DESCRIPTION
## Summary
- add a finance management hook
- create functional components for income, debt, expense, and summary
- add a new finance screen that uses these components

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684360fae5e48331ae313924d32b8efe