### PR TITLE
Add global theme and finance context

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,75 +1,38 @@
-import { Image } from 'expo-image';
-import { Platform, StyleSheet } from 'react-native';
+import { Link } from 'expo-router';
+import { StyleSheet, View, Pressable } from 'react-native';
 
-import { HelloWave } from '@/components/HelloWave';
-import ParallaxScrollView from '@/components/ParallaxScrollView';
+import BalanceChart from '@/components/finance/BalanceChart';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
+import { useFinance } from '@/context/FinanceContext';
+import { useAppTheme } from '@/context/ThemeContext';
 
 export default function HomeScreen() {
+  const finance = useFinance();
+  const { colors, toggleTheme } = useAppTheme();
+
   return (
-    <ParallaxScrollView
-      headerBackgroundColor={{ light: '#A1CEDC', dark: '#1D3D47' }}
-      headerImage={
-        <Image
-          source={require('@/assets/images/partial-react-logo.png')}
-          style={styles.reactLogo}
-        />
-      }>
-      <ThemedView style={styles.titleContainer}>
-        <ThemedText type="title">Welcome!</ThemedText>
-        <HelloWave />
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 1: Try it</ThemedText>
-        <ThemedText>
-          Edit <ThemedText type="defaultSemiBold">app/(tabs)/index.tsx</ThemedText> to see changes.
-          Press{' '}
-          <ThemedText type="defaultSemiBold">
-            {Platform.select({
-              ios: 'cmd + d',
-              android: 'cmd + m',
-              web: 'F12',
-            })}
-          </ThemedText>{' '}
-          to open developer tools.
-        </ThemedText>
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 2: Explore</ThemedText>
-        <ThemedText>
-          {`Tap the Explore tab to learn more about what's included in this starter app.`}
-        </ThemedText>
-      </ThemedView>
-      <ThemedView style={styles.stepContainer}>
-        <ThemedText type="subtitle">Step 3: Get a fresh start</ThemedText>
-        <ThemedText>
-          {`When you're ready, run `}
-          <ThemedText type="defaultSemiBold">npm run reset-project</ThemedText> to get a fresh{' '}
-          <ThemedText type="defaultSemiBold">app</ThemedText> directory. This will move the current{' '}
-          <ThemedText type="defaultSemiBold">app</ThemedText> to{' '}
-          <ThemedText type="defaultSemiBold">app-example</ThemedText>.
-        </ThemedText>
-      </ThemedView>
-    </ParallaxScrollView>
+    <ThemedView style={[styles.container, { backgroundColor: colors.bg }]}>
+      <View style={styles.menu}>
+        <Link href="/finanzas" style={[styles.menuItem, { backgroundColor: colors.primary }]}>
+          <ThemedText lightColor="#fff" darkColor="#fff">Finanzas</ThemedText>
+        </Link>
+        <Pressable onPress={toggleTheme} style={styles.menuItem}>
+          <ThemedText>🌓</ThemedText>
+        </Pressable>
+      </View>
+      <BalanceChart
+        ingresos={finance.ingresoTotal}
+        deudas={finance.deudaTotal}
+        gastos={finance.gastoTotal}
+        colors={colors}
+      />
+    </ThemedView>
   );
 }
 
 const styles = StyleSheet.create({
-  titleContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-  },
-  stepContainer: {
-    gap: 8,
-    marginBottom: 8,
-  },
-  reactLogo: {
-    height: 178,
-    width: 290,
-    bottom: 0,
-    left: 0,
-    position: 'absolute',
-  },
+  container: { flex: 1, padding: 16 },
+  menu: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 16 },
+  menuItem: { padding: 8, borderRadius: 4 },
 });

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,29 +1,29 @@
-import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
-import { useFonts } from 'expo-font';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
+import { useFonts } from 'expo-font';
 import 'react-native-reanimated';
 
-import { useColorScheme } from '@/hooks/useColorScheme';
+import { AppThemeProvider } from '@/context/ThemeContext';
+import { FinanceProvider } from '@/context/FinanceContext';
 
 export default function RootLayout() {
-  const colorScheme = useColorScheme();
   const [loaded] = useFonts({
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
   });
 
   if (!loaded) {
-    // Async font loading only occurs in development.
     return null;
   }
 
   return (
-    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <Stack>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-        <Stack.Screen name="+not-found" />
-      </Stack>
-      <StatusBar style="auto" />
-    </ThemeProvider>
+    <AppThemeProvider>
+      <FinanceProvider>
+        <Stack>
+          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+          <Stack.Screen name="+not-found" />
+        </Stack>
+        <StatusBar style="auto" />
+      </FinanceProvider>
+    </AppThemeProvider>
   );
 }

--- a/app/finanzas.tsx
+++ b/app/finanzas.tsx
@@ -1,39 +1,22 @@
-import { useState } from 'react';
 import { ScrollView, View, Text, StyleSheet, Pressable } from 'react-native';
 
-import IncomeSection, { Colors } from '@/components/finance/IncomeSection';
+import IncomeSection from '@/components/finance/IncomeSection';
 import DebtSection from '@/components/finance/DebtSection';
 import ExpenseSection from '@/components/finance/ExpenseSection';
 import BalanceSummary from '@/components/finance/BalanceSummary';
 import BalanceChart from '@/components/finance/BalanceChart';
-import { useFinanzas } from '@/hooks/useFinanzas';
-
-const lightColors: Colors = {
-  bg: '#f4f4f4',
-  text: '#222',
-  surface: '#ffffff',
-  primary: '#004388',
-  accent: '#00acac',
-};
-
-const darkColors: Colors = {
-  bg: '#1e1e1e',
-  text: '#f4f4f4',
-  surface: '#2c2c2c',
-  primary: '#00acac',
-  accent: '#8ec89a',
-};
+import { useFinance } from '@/context/FinanceContext';
+import { useAppTheme } from '@/context/ThemeContext';
 
 export default function FinanzasScreen() {
-  const [theme, setTheme] = useState<'light' | 'dark'>('dark');
-  const colors = theme === 'dark' ? darkColors : lightColors;
-  const finance = useFinanzas();
+  const finance = useFinance();
+  const { colors, toggleTheme } = useAppTheme();
 
   return (
     <ScrollView style={[styles.container, { backgroundColor: colors.bg }]}>
       <View style={[styles.header, { backgroundColor: colors.primary }]}>
         <Text style={[styles.headerText, { color: '#fff' }]}>Mis Finanzas Personales</Text>
-        <Pressable onPress={() => setTheme(theme === 'dark' ? 'light' : 'dark')}> 
+        <Pressable onPress={toggleTheme}>
           <Text style={styles.toggle}>🌓</Text>
         </Pressable>
       </View>

--- a/components/finance/BalanceChart.tsx
+++ b/components/finance/BalanceChart.tsx
@@ -1,6 +1,6 @@
 import { View, Text, StyleSheet } from 'react-native';
 
-import type { Colors } from './IncomeSection';
+import type { Colors } from '@/context/ThemeContext';
 
 interface Props {
   ingresos: number;

--- a/components/finance/BalanceSummary.tsx
+++ b/components/finance/BalanceSummary.tsx
@@ -1,6 +1,6 @@
 import { View, Text, StyleSheet } from 'react-native';
 
-import type { Colors } from './IncomeSection';
+import type { Colors } from '@/context/ThemeContext';
 
 interface Props {
   balance: number;

--- a/components/finance/DebtSection.tsx
+++ b/components/finance/DebtSection.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
 
 import type { Deuda } from '@/hooks/useFinanzas';
-import type { Colors } from './IncomeSection';
+import type { Colors } from '@/context/ThemeContext';
 
 interface Props {
   deudas: Deuda[];

--- a/components/finance/ExpenseSection.tsx
+++ b/components/finance/ExpenseSection.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
 
 import type { Gasto } from '@/hooks/useFinanzas';
-import type { Colors } from './IncomeSection';
+import type { Colors } from '@/context/ThemeContext';
 
 interface Props {
   gastos: Gasto[];

--- a/components/finance/IncomeSection.tsx
+++ b/components/finance/IncomeSection.tsx
@@ -2,19 +2,12 @@ import { useState } from 'react';
 import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
 
 import type { Ingreso } from '@/hooks/useFinanzas';
+import type { Colors } from '@/context/ThemeContext';
 
 interface Props {
   ingresos: Ingreso[];
   onAdd: (ingreso: Ingreso) => void;
   colors: Colors;
-}
-
-export interface Colors {
-  bg: string;
-  text: string;
-  surface: string;
-  primary: string;
-  accent: string;
 }
 
 export default function IncomeSection({ ingresos, onAdd, colors }: Props) {

--- a/context/FinanceContext.tsx
+++ b/context/FinanceContext.tsx
@@ -1,0 +1,17 @@
+import React, { createContext, useContext, ReactNode } from 'react';
+import { useFinanzas } from '@/hooks/useFinanzas';
+
+const FinanceContext = createContext<ReturnType<typeof useFinanzas> | null>(null);
+
+export function FinanceProvider({ children }: { children: ReactNode }) {
+  const finance = useFinanzas();
+  return <FinanceContext.Provider value={finance}>{children}</FinanceContext.Provider>;
+}
+
+export function useFinance() {
+  const ctx = useContext(FinanceContext);
+  if (!ctx) {
+    throw new Error('useFinance must be used within FinanceProvider');
+  }
+  return ctx;
+}

--- a/context/ThemeContext.tsx
+++ b/context/ThemeContext.tsx
@@ -1,0 +1,59 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+import { DarkTheme, DefaultTheme, ThemeProvider as NavigationThemeProvider } from '@react-navigation/native';
+import { useColorScheme as useSystemColorScheme } from 'react-native';
+
+export type ThemeName = 'light' | 'dark';
+
+export interface Colors {
+  bg: string;
+  text: string;
+  surface: string;
+  primary: string;
+  accent: string;
+}
+
+const softColors: Colors = {
+  bg: '#f4f4f4',
+  text: '#222',
+  surface: '#ffffff',
+  primary: '#004388',
+  accent: '#00acac',
+};
+
+const darkColors: Colors = {
+  bg: '#1e1e1e',
+  text: '#f4f4f4',
+  surface: '#2c2c2c',
+  primary: '#00acac',
+  accent: '#8ec89a',
+};
+
+interface ThemeContextValue {
+  theme: ThemeName;
+  colors: Colors;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: 'light',
+  colors: softColors,
+  toggleTheme: () => {},
+});
+
+export const useAppTheme = () => useContext(ThemeContext);
+
+export function AppThemeProvider({ children }: { children: ReactNode }) {
+  const system = useSystemColorScheme();
+  const [theme, setTheme] = useState<ThemeName>(system === 'dark' ? 'dark' : 'light');
+  const colors = theme === 'dark' ? darkColors : softColors;
+
+  const toggleTheme = () => setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'));
+
+  return (
+    <ThemeContext.Provider value={{ theme, colors, toggleTheme }}>
+      <NavigationThemeProvider value={theme === 'dark' ? DarkTheme : DefaultTheme}>
+        {children}
+      </NavigationThemeProvider>
+    </ThemeContext.Provider>
+  );
+}

--- a/hooks/useColorScheme.ts
+++ b/hooks/useColorScheme.ts
@@ -1,1 +1,9 @@
-export { useColorScheme } from 'react-native';
+import { useContext } from 'react';
+import { useColorScheme as useRNColorScheme } from 'react-native';
+import { useAppTheme } from '@/context/ThemeContext';
+
+export function useColorScheme() {
+  const { theme } = useAppTheme();
+  const system = useRNColorScheme();
+  return theme ?? system ?? 'light';
+}

--- a/hooks/useColorScheme.web.ts
+++ b/hooks/useColorScheme.web.ts
@@ -1,20 +1,19 @@
 import { useEffect, useState } from 'react';
 import { useColorScheme as useRNColorScheme } from 'react-native';
+import { useAppTheme } from '@/context/ThemeContext';
 
-/**
- * To support static rendering, this value needs to be re-calculated on the client side for web
- */
 export function useColorScheme() {
+  const { theme } = useAppTheme();
   const [hasHydrated, setHasHydrated] = useState(false);
 
   useEffect(() => {
     setHasHydrated(true);
   }, []);
 
-  const colorScheme = useRNColorScheme();
+  const system = useRNColorScheme();
 
   if (hasHydrated) {
-    return colorScheme;
+    return theme ?? system ?? 'light';
   }
 
   return 'light';


### PR DESCRIPTION
## Summary
- add global ThemeContext and FinanceContext
- refactor Finanzas page to use context values
- show finance chart and navigation on home screen
- integrate contexts in app layout
- route colors with context color scheme

## Testing
- `npm run lint` *(fails: expo not found)*
- `npx tsc -p tsconfig.json` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684362f26fe08331b6c0fb927c18bb35