### PR TITLE
Add finance charts and detail views

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ This is an [Expo](https://expo.dev) project created with [`create-expo-app`](htt
 
    ```bash
    npm install
+   # required for charts
+   npx expo install react-native-svg
+   npm install react-native-chart-kit
    ```
 
 2. Start the app

--- a/app/(modals)/_layout.tsx
+++ b/app/(modals)/_layout.tsx
@@ -1,0 +1,5 @@
+import { Stack } from 'expo-router';
+
+export default function ModalLayout() {
+  return <Stack screenOptions={{ presentation: 'modal', headerShown: false }} />;
+}

--- a/app/(modals)/deuda.tsx
+++ b/app/(modals)/deuda.tsx
@@ -1,0 +1,118 @@
+import { useState } from 'react';
+import { SafeAreaView, View, Text, TextInput, StyleSheet, Switch } from 'react-native';
+import { useRouter } from 'expo-router';
+
+import AppButton from '@/components/AppButton';
+import { useFinance } from '@/context/FinanceContext';
+import { useAppTheme } from '@/context/ThemeContext';
+
+export default function AddDeudaModal() {
+  const { colors } = useAppTheme();
+  const finance = useFinance();
+  const router = useRouter();
+
+  const [concepto, setConcepto] = useState('');
+  const [monto, setMonto] = useState('');
+  const [meses, setMeses] = useState('');
+  const [indefinido, setIndefinido] = useState(true);
+  const [tieneAumento, setTieneAumento] = useState(false);
+  const [aumento, setAumento] = useState('');
+  const [aumentoMeses, setAumentoMeses] = useState('');
+
+  const handleSave = () => {
+    const montoNum = parseFloat(monto);
+    const mesesNum = parseInt(meses, 10);
+    const aumentoNum = parseFloat(aumento);
+    const aumentoMesNum = parseInt(aumentoMeses, 10);
+    if (!concepto || isNaN(montoNum)) return;
+    finance.agregarDeuda({
+      concepto,
+      monto: montoNum,
+      meses: indefinido || isNaN(mesesNum) ? 0 : mesesNum,
+      aumento: tieneAumento && !isNaN(aumentoNum) ? aumentoNum : undefined,
+      aumentoFrecuencia: tieneAumento && !isNaN(aumentoMesNum) ? aumentoMesNum : undefined,
+    });
+    router.back();
+  };
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
+      <View style={[styles.content, { backgroundColor: colors.surface }]}>
+        <Text style={[styles.title, { color: colors.text }]}>Nueva Deuda</Text>
+        <View style={styles.group}>
+          <Text style={{ color: colors.text }}>Concepto</Text>
+          <TextInput
+            value={concepto}
+            onChangeText={setConcepto}
+            style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
+          />
+        </View>
+        <View style={styles.group}>
+          <Text style={{ color: colors.text }}>Monto</Text>
+          <TextInput
+            value={monto}
+            onChangeText={setMonto}
+            keyboardType="numeric"
+            style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
+          />
+        </View>
+        <View style={styles.group}>
+          <View style={styles.switchRow}>
+            <Text style={{ color: colors.text }}>Indefinido</Text>
+            <Switch value={indefinido} onValueChange={setIndefinido} />
+          </View>
+        </View>
+        {!indefinido && (
+          <View style={styles.group}>
+            <Text style={{ color: colors.text }}>Meses</Text>
+            <TextInput
+              value={meses}
+              onChangeText={setMeses}
+              keyboardType="numeric"
+              style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
+            />
+          </View>
+        )}
+        <View style={styles.group}>
+          <View style={styles.switchRow}>
+            <Text style={{ color: colors.text }}>Aumento pactado</Text>
+            <Switch value={tieneAumento} onValueChange={setTieneAumento} />
+          </View>
+        </View>
+        {tieneAumento && (
+          <>
+            <View style={styles.group}>
+              <Text style={{ color: colors.text }}>Porcentaje de aumento</Text>
+              <TextInput
+                value={aumento}
+                onChangeText={setAumento}
+                keyboardType="numeric"
+                style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
+              />
+            </View>
+            <View style={styles.group}>
+              <Text style={{ color: colors.text }}>Cada cuantos meses</Text>
+              <TextInput
+                value={aumentoMeses}
+                onChangeText={setAumentoMeses}
+                keyboardType="numeric"
+                style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
+              />
+            </View>
+          </>
+        )}
+        <AppButton title="Guardar" color={colors.primary} onPress={handleSave} />
+        <AppButton title="Cancelar" color={colors.accent} onPress={() => router.back()} />
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16 },
+  content: { borderRadius: 8, padding: 16 },
+  title: { fontSize: 18, fontWeight: 'bold', marginBottom: 12 },
+  group: { marginBottom: 12 },
+  input: { borderWidth: 1, borderRadius: 6, padding: 8, marginTop: 4 },
+  switchRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
+});

--- a/app/(modals)/gasto.tsx
+++ b/app/(modals)/gasto.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react';
+import { SafeAreaView, View, Text, TextInput, StyleSheet } from 'react-native';
+import { useRouter } from 'expo-router';
+
+import AppButton from '@/components/AppButton';
+import { useFinance } from '@/context/FinanceContext';
+import { useAppTheme } from '@/context/ThemeContext';
+
+export default function AddGastoModal() {
+  const { colors } = useAppTheme();
+  const finance = useFinance();
+  const router = useRouter();
+
+  const [concepto, setConcepto] = useState('');
+  const [monto, setMonto] = useState('');
+
+  const handleSave = () => {
+    const montoNum = parseFloat(monto);
+    if (!concepto || isNaN(montoNum)) return;
+    finance.agregarGasto({ concepto, monto: montoNum });
+    router.back();
+  };
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
+      <View style={[styles.content, { backgroundColor: colors.surface }]}>
+        <Text style={[styles.title, { color: colors.text }]}>Nuevo Gasto</Text>
+        <View style={styles.group}>
+          <Text style={{ color: colors.text }}>Concepto</Text>
+          <TextInput
+            value={concepto}
+            onChangeText={setConcepto}
+            style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
+          />
+        </View>
+        <View style={styles.group}>
+          <Text style={{ color: colors.text }}>Monto</Text>
+          <TextInput
+            value={monto}
+            onChangeText={setMonto}
+            keyboardType="numeric"
+            style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
+          />
+        </View>
+        <AppButton title="Guardar" color={colors.primary} onPress={handleSave} />
+        <AppButton title="Cancelar" color={colors.accent} onPress={() => router.back()} />
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16 },
+  content: { borderRadius: 8, padding: 16 },
+  title: { fontSize: 18, fontWeight: 'bold', marginBottom: 12 },
+  group: { marginBottom: 12 },
+  input: { borderWidth: 1, borderRadius: 6, padding: 8, marginTop: 4 },
+});

--- a/app/(modals)/ingreso.tsx
+++ b/app/(modals)/ingreso.tsx
@@ -1,0 +1,118 @@
+import { useState } from 'react';
+import { SafeAreaView, View, Text, TextInput, StyleSheet, Switch } from 'react-native';
+import { useRouter } from 'expo-router';
+
+import AppButton from '@/components/AppButton';
+import { useFinance } from '@/context/FinanceContext';
+import { useAppTheme } from '@/context/ThemeContext';
+
+export default function AddIngresoModal() {
+  const { colors } = useAppTheme();
+  const finance = useFinance();
+  const router = useRouter();
+
+  const [concepto, setConcepto] = useState('');
+  const [monto, setMonto] = useState('');
+  const [meses, setMeses] = useState('');
+  const [indefinido, setIndefinido] = useState(true);
+  const [tieneAumento, setTieneAumento] = useState(false);
+  const [aumento, setAumento] = useState('');
+  const [aumentoMeses, setAumentoMeses] = useState('');
+
+  const handleSave = () => {
+    const montoNum = parseFloat(monto);
+    const mesesNum = parseInt(meses, 10);
+    const aumentoNum = parseFloat(aumento);
+    const aumentoMesNum = parseInt(aumentoMeses, 10);
+    if (!concepto || isNaN(montoNum)) return;
+    finance.agregarIngreso({
+      concepto,
+      monto: montoNum,
+      meses: indefinido || isNaN(mesesNum) ? 0 : mesesNum,
+      aumento: tieneAumento && !isNaN(aumentoNum) ? aumentoNum : undefined,
+      aumentoFrecuencia: tieneAumento && !isNaN(aumentoMesNum) ? aumentoMesNum : undefined,
+    });
+    router.back();
+  };
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
+      <View style={[styles.content, { backgroundColor: colors.surface }]}>
+        <Text style={[styles.title, { color: colors.text }]}>Nuevo Ingreso</Text>
+        <View style={styles.group}>
+          <Text style={{ color: colors.text }}>Concepto</Text>
+          <TextInput
+            value={concepto}
+            onChangeText={setConcepto}
+            style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
+          />
+        </View>
+        <View style={styles.group}>
+          <Text style={{ color: colors.text }}>Monto</Text>
+          <TextInput
+            value={monto}
+            onChangeText={setMonto}
+            keyboardType="numeric"
+            style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
+          />
+        </View>
+        <View style={styles.group}>
+          <View style={styles.switchRow}>
+            <Text style={{ color: colors.text }}>Indefinido</Text>
+            <Switch value={indefinido} onValueChange={setIndefinido} />
+          </View>
+        </View>
+        {!indefinido && (
+          <View style={styles.group}>
+            <Text style={{ color: colors.text }}>Meses</Text>
+            <TextInput
+              value={meses}
+              onChangeText={setMeses}
+              keyboardType="numeric"
+              style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
+            />
+          </View>
+        )}
+        <View style={styles.group}>
+          <View style={styles.switchRow}>
+            <Text style={{ color: colors.text }}>Aumento pactado</Text>
+            <Switch value={tieneAumento} onValueChange={setTieneAumento} />
+          </View>
+        </View>
+        {tieneAumento && (
+          <>
+            <View style={styles.group}>
+              <Text style={{ color: colors.text }}>Porcentaje de aumento</Text>
+              <TextInput
+                value={aumento}
+                onChangeText={setAumento}
+                keyboardType="numeric"
+                style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
+              />
+            </View>
+            <View style={styles.group}>
+              <Text style={{ color: colors.text }}>Cada cuantos meses</Text>
+              <TextInput
+                value={aumentoMeses}
+                onChangeText={setAumentoMeses}
+                keyboardType="numeric"
+                style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
+              />
+            </View>
+          </>
+        )}
+        <AppButton title="Guardar" color={colors.primary} onPress={handleSave} />
+        <AppButton title="Cancelar" color={colors.accent} onPress={() => router.back()} />
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 16 },
+  content: { borderRadius: 8, padding: 16 },
+  title: { fontSize: 18, fontWeight: 'bold', marginBottom: 12 },
+  group: { marginBottom: 12 },
+  input: { borderWidth: 1, borderRadius: 6, padding: 8, marginTop: 4 },
+  switchRow: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
+});

--- a/app/(tabs)/finanzas.tsx
+++ b/app/(tabs)/finanzas.tsx
@@ -1,6 +1,6 @@
 import { ScrollView, View, Text, StyleSheet, Pressable, Modal } from 'react-native';
 import { useState } from 'react';
-import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useRouter } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import FloatingAddMenu from '@/components/FloatingAddMenu';
 
@@ -18,7 +18,6 @@ export default function FinanzasScreen() {
   const { colors, toggleTheme } = useAppTheme();
   const { currency, setCurrency } = useCurrency();
   const [showCurrency, setShowCurrency] = useState(false);
-  const params = useLocalSearchParams<{ add?: string }>();
   const router = useRouter();
 
   return (
@@ -40,7 +39,6 @@ export default function FinanzasScreen() {
             ingresos={finance.ingresos}
             onAdd={finance.agregarIngreso}
             colors={colors}
-            autoOpen={params.add === 'ingreso'}
           />
           <Pressable onPress={() => router.push('/ingresos')}>
             <Text style={[styles.link, { color: colors.primary }]}>Ver detalle</Text>
@@ -49,7 +47,6 @@ export default function FinanzasScreen() {
             deudas={finance.deudas}
             onAdd={finance.agregarDeuda}
             colors={colors}
-            autoOpen={params.add === 'deuda'}
           />
           <Pressable onPress={() => router.push('/deudas')}>
             <Text style={[styles.link, { color: colors.primary }]}>Ver detalle</Text>
@@ -58,7 +55,6 @@ export default function FinanzasScreen() {
             gastos={finance.gastos}
             onAdd={finance.agregarGasto}
             colors={colors}
-            autoOpen={params.add === 'gasto'}
           />
           <Pressable onPress={() => router.push('/gastos')}>
             <Text style={[styles.link, { color: colors.primary }]}>Ver detalle</Text>
@@ -86,9 +82,9 @@ export default function FinanzasScreen() {
       </ScrollView>
       <FloatingAddMenu
         colors={colors}
-        onIngreso={() => router.push('/finanzas?add=ingreso')}
-        onDeuda={() => router.push('/finanzas?add=deuda')}
-        onGasto={() => router.push('/finanzas?add=gasto')}
+        onIngreso={() => router.push('/(modals)/ingreso')}
+        onDeuda={() => router.push('/(modals)/deuda')}
+        onGasto={() => router.push('/(modals)/gasto')}
       />
     </SafeAreaView>
   );

--- a/app/(tabs)/finanzas.tsx
+++ b/app/(tabs)/finanzas.tsx
@@ -35,27 +35,15 @@ export default function FinanzasScreen() {
           </View>
         </View>
         <View style={styles.content}>
-          <IncomeSection
-            ingresos={finance.ingresos}
-            onAdd={finance.agregarIngreso}
-            colors={colors}
-          />
+          <IncomeSection ingresos={finance.ingresos} colors={colors} />
           <Pressable onPress={() => router.push('/ingresos')}>
             <Text style={[styles.link, { color: colors.primary }]}>Ver detalle</Text>
           </Pressable>
-          <DebtSection
-            deudas={finance.deudas}
-            onAdd={finance.agregarDeuda}
-            colors={colors}
-          />
+          <DebtSection deudas={finance.deudas} colors={colors} />
           <Pressable onPress={() => router.push('/deudas')}>
             <Text style={[styles.link, { color: colors.primary }]}>Ver detalle</Text>
           </Pressable>
-          <ExpenseSection
-            gastos={finance.gastos}
-            onAdd={finance.agregarGasto}
-            colors={colors}
-          />
+          <ExpenseSection gastos={finance.gastos} colors={colors} />
           <Pressable onPress={() => router.push('/gastos')}>
             <Text style={[styles.link, { color: colors.primary }]}>Ver detalle</Text>
           </Pressable>

--- a/app/(tabs)/finanzas.tsx
+++ b/app/(tabs)/finanzas.tsx
@@ -62,7 +62,13 @@ export default function FinanzasScreen() {
           <Pressable onPress={() => router.push('/gastos')}>
             <Text style={[styles.link, { color: colors.primary }]}>Ver detalle</Text>
           </Pressable>
-          <BalanceChart ingresos={finance.ingresoTotal} deudas={finance.deudaTotal} gastos={finance.gastoTotal} colors={colors} />
+          <BalanceChart
+            ingresos={finance.ingresos}
+            deudas={finance.deudas}
+            gastos={finance.gastos}
+            colors={colors}
+            onAddPress={() => router.push('/finanzas?add=ingreso')}
+          />
         </View>
         <Modal transparent animationType="slide" visible={showCurrency}>
           <View style={styles.modalBackdrop}>

--- a/app/(tabs)/finanzas.tsx
+++ b/app/(tabs)/finanzas.tsx
@@ -2,6 +2,7 @@ import { ScrollView, View, Text, StyleSheet, Pressable, Modal } from 'react-nati
 import { useState } from 'react';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import FloatingAddMenu from '@/components/FloatingAddMenu';
 
 import IncomeSection from '@/components/finance/IncomeSection';
 import DebtSection from '@/components/finance/DebtSection';
@@ -67,7 +68,6 @@ export default function FinanzasScreen() {
             deudas={finance.deudas}
             gastos={finance.gastos}
             colors={colors}
-            onAddPress={() => router.push('/finanzas?add=ingreso')}
           />
         </View>
         <Modal transparent animationType="slide" visible={showCurrency}>
@@ -84,6 +84,12 @@ export default function FinanzasScreen() {
           </View>
         </Modal>
       </ScrollView>
+      <FloatingAddMenu
+        colors={colors}
+        onIngreso={() => router.push('/finanzas?add=ingreso')}
+        onDeuda={() => router.push('/finanzas?add=deuda')}
+        onGasto={() => router.push('/finanzas?add=gasto')}
+      />
     </SafeAreaView>
   );
 }

--- a/app/(tabs)/finanzas.tsx
+++ b/app/(tabs)/finanzas.tsx
@@ -1,6 +1,6 @@
 import { ScrollView, View, Text, StyleSheet, Pressable, Modal } from 'react-native';
 import { useState } from 'react';
-import { useLocalSearchParams } from 'expo-router';
+import { useLocalSearchParams, useRouter } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import IncomeSection from '@/components/finance/IncomeSection';
@@ -18,6 +18,7 @@ export default function FinanzasScreen() {
   const { currency, setCurrency } = useCurrency();
   const [showCurrency, setShowCurrency] = useState(false);
   const params = useLocalSearchParams<{ add?: string }>();
+  const router = useRouter();
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
@@ -40,18 +41,27 @@ export default function FinanzasScreen() {
             colors={colors}
             autoOpen={params.add === 'ingreso'}
           />
+          <Pressable onPress={() => router.push('/ingresos')}>
+            <Text style={[styles.link, { color: colors.primary }]}>Ver detalle</Text>
+          </Pressable>
           <DebtSection
             deudas={finance.deudas}
             onAdd={finance.agregarDeuda}
             colors={colors}
             autoOpen={params.add === 'deuda'}
           />
+          <Pressable onPress={() => router.push('/deudas')}>
+            <Text style={[styles.link, { color: colors.primary }]}>Ver detalle</Text>
+          </Pressable>
           <ExpenseSection
             gastos={finance.gastos}
             onAdd={finance.agregarGasto}
             colors={colors}
             autoOpen={params.add === 'gasto'}
           />
+          <Pressable onPress={() => router.push('/gastos')}>
+            <Text style={[styles.link, { color: colors.primary }]}>Ver detalle</Text>
+          </Pressable>
           <BalanceChart ingresos={finance.ingresoTotal} deudas={finance.deudaTotal} gastos={finance.gastoTotal} colors={colors} />
         </View>
         <Modal transparent animationType="slide" visible={showCurrency}>
@@ -116,5 +126,8 @@ const styles = StyleSheet.create({
   },
   scrollContent: {
     paddingBottom: 16,
+  },
+  link: {
+    marginBottom: 8,
   },
 });

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,5 +1,6 @@
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import FloatingAddMenu from '@/components/FloatingAddMenu';
 import { useRouter } from 'expo-router';
 import BalanceChart from '@/components/finance/BalanceChart';
 import BalanceSummary from '@/components/finance/BalanceSummary';
@@ -31,7 +32,6 @@ export default function HomeScreen() {
                 deudas={finance.deudas}
                 gastos={finance.gastos}
                 colors={colors}
-                onAddPress={() => router.push('/finanzas?add=ingreso')}
               />
             </>
           ) : (
@@ -42,7 +42,6 @@ export default function HomeScreen() {
                 deudas={[{ concepto: 'Ejemplo', monto: 500, meses: 0 }]}
                 gastos={[{ concepto: 'Ejemplo', monto: 800 }]}
                 colors={colors}
-                onAddPress={() => router.push('/finanzas?add=ingreso')}
               />
               <Text style={[styles.message, { color: colors.text }]}> 
                 Agrega información en la página de finanzas para ver tus propias
@@ -53,6 +52,12 @@ export default function HomeScreen() {
           )}
         </View>
       </ScrollView>
+      <FloatingAddMenu
+        colors={colors}
+        onIngreso={() => router.push('/finanzas?add=ingreso')}
+        onDeuda={() => router.push('/finanzas?add=deuda')}
+        onGasto={() => router.push('/finanzas?add=gasto')}
+      />
     </SafeAreaView>
   );
 }

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,4 +1,5 @@
-import { SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useRouter } from 'expo-router';
 import BalanceChart from '@/components/finance/BalanceChart';
 import BalanceSummary from '@/components/finance/BalanceSummary';
@@ -26,9 +27,9 @@ export default function HomeScreen() {
             <>
               <BalanceSummary balance={finance.balance} colors={colors} />
               <BalanceChart
-                ingresos={finance.ingresoTotal}
-                deudas={finance.deudaTotal}
-                gastos={finance.gastoTotal}
+                ingresos={finance.ingresos}
+                deudas={finance.deudas}
+                gastos={finance.gastos}
                 colors={colors}
                 onAddPress={() => router.push('/finanzas?add=ingreso')}
               />
@@ -37,9 +38,9 @@ export default function HomeScreen() {
             <>
               <BalanceSummary balance={0} colors={colors} />
               <BalanceChart
-                ingresos={2000}
-                deudas={500}
-                gastos={800}
+                ingresos={[{ concepto: 'Ejemplo', monto: 2000, meses: 0 }]}
+                deudas={[{ concepto: 'Ejemplo', monto: 500, meses: 0 }]}
+                gastos={[{ concepto: 'Ejemplo', monto: 800 }]}
                 colors={colors}
                 onAddPress={() => router.push('/finanzas?add=ingreso')}
               />

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -54,9 +54,9 @@ export default function HomeScreen() {
       </ScrollView>
       <FloatingAddMenu
         colors={colors}
-        onIngreso={() => router.push('/finanzas?add=ingreso')}
-        onDeuda={() => router.push('/finanzas?add=deuda')}
-        onGasto={() => router.push('/finanzas?add=gasto')}
+        onIngreso={() => router.push('/(modals)/ingreso')}
+        onDeuda={() => router.push('/(modals)/deuda')}
+        onGasto={() => router.push('/(modals)/gasto')}
       />
     </SafeAreaView>
   );

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,6 +2,7 @@ import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useFonts } from 'expo-font';
 import 'react-native-reanimated';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 import { AppThemeProvider } from '@/context/ThemeContext';
 import { FinanceProvider } from '@/context/FinanceContext';
@@ -17,16 +18,18 @@ export default function RootLayout() {
   }
 
   return (
-    <AppThemeProvider>
-      <CurrencyProvider>
-        <FinanceProvider>
-          <Stack>
-            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-            <Stack.Screen name="+not-found" />
-          </Stack>
-          <StatusBar style="auto" />
-        </FinanceProvider>
-      </CurrencyProvider>
-    </AppThemeProvider>
+    <SafeAreaProvider>
+      <AppThemeProvider>
+        <CurrencyProvider>
+          <FinanceProvider>
+            <Stack>
+              <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+              <Stack.Screen name="+not-found" />
+            </Stack>
+            <StatusBar style="auto" />
+          </FinanceProvider>
+        </CurrencyProvider>
+      </AppThemeProvider>
+    </SafeAreaProvider>
   );
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -24,6 +24,7 @@ export default function RootLayout() {
           <FinanceProvider>
             <Stack>
               <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+              <Stack.Screen name="(modals)" options={{ presentation: 'modal', headerShown: false }} />
               <Stack.Screen name="+not-found" />
             </Stack>
             <StatusBar style="auto" />

--- a/app/deudas.tsx
+++ b/app/deudas.tsx
@@ -1,0 +1,48 @@
+import { SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
+import ConceptChart from '@/components/finance/ConceptChart';
+import { useFinance } from '@/context/FinanceContext';
+import { useAppTheme } from '@/context/ThemeContext';
+import { useCurrency } from '@/context/CurrencyContext';
+
+export default function DeudasScreen() {
+  const { deudas } = useFinance();
+  const { colors } = useAppTheme();
+  const { format } = useCurrency();
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <Text style={[styles.title, { color: colors.text }]}>Deudas</Text>
+        {deudas.map((d, idx) => (
+          <View key={idx} style={styles.item}>
+            <Text style={[styles.itemText, { color: colors.text }]}>{d.concepto}</Text>
+            <Text style={[styles.itemText, { color: colors.text }]}>{format(d.monto)}</Text>
+          </View>
+        ))}
+        <ConceptChart items={deudas} colors={colors} />
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 16,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    marginBottom: 8,
+  },
+  item: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 4,
+  },
+  itemText: {
+    fontSize: 16,
+  },
+});

--- a/app/deudas.tsx
+++ b/app/deudas.tsx
@@ -1,4 +1,5 @@
-import { SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import ConceptChart from '@/components/finance/ConceptChart';
 import { useFinance } from '@/context/FinanceContext';
 import { useAppTheme } from '@/context/ThemeContext';

--- a/app/gastos.tsx
+++ b/app/gastos.tsx
@@ -1,4 +1,5 @@
-import { SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import ConceptChart from '@/components/finance/ConceptChart';
 import { useFinance } from '@/context/FinanceContext';
 import { useAppTheme } from '@/context/ThemeContext';

--- a/app/gastos.tsx
+++ b/app/gastos.tsx
@@ -1,0 +1,48 @@
+import { SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
+import ConceptChart from '@/components/finance/ConceptChart';
+import { useFinance } from '@/context/FinanceContext';
+import { useAppTheme } from '@/context/ThemeContext';
+import { useCurrency } from '@/context/CurrencyContext';
+
+export default function GastosScreen() {
+  const { gastos } = useFinance();
+  const { colors } = useAppTheme();
+  const { format } = useCurrency();
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <Text style={[styles.title, { color: colors.text }]}>Gastos</Text>
+        {gastos.map((g, idx) => (
+          <View key={idx} style={styles.item}>
+            <Text style={[styles.itemText, { color: colors.text }]}>{g.concepto}</Text>
+            <Text style={[styles.itemText, { color: colors.text }]}>{format(g.monto)}</Text>
+          </View>
+        ))}
+        <ConceptChart items={gastos} colors={colors} />
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 16,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    marginBottom: 8,
+  },
+  item: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 4,
+  },
+  itemText: {
+    fontSize: 16,
+  },
+});

--- a/app/ingresos.tsx
+++ b/app/ingresos.tsx
@@ -1,4 +1,5 @@
-import { SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import ConceptChart from '@/components/finance/ConceptChart';
 import { useFinance } from '@/context/FinanceContext';
 import { useAppTheme } from '@/context/ThemeContext';

--- a/app/ingresos.tsx
+++ b/app/ingresos.tsx
@@ -1,0 +1,48 @@
+import { SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
+import ConceptChart from '@/components/finance/ConceptChart';
+import { useFinance } from '@/context/FinanceContext';
+import { useAppTheme } from '@/context/ThemeContext';
+import { useCurrency } from '@/context/CurrencyContext';
+
+export default function IngresosScreen() {
+  const { ingresos } = useFinance();
+  const { colors } = useAppTheme();
+  const { format } = useCurrency();
+
+  return (
+    <SafeAreaView style={[styles.container, { backgroundColor: colors.bg }]}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <Text style={[styles.title, { color: colors.text }]}>Ingresos</Text>
+        {ingresos.map((i, idx) => (
+          <View key={idx} style={styles.item}>
+            <Text style={[styles.itemText, { color: colors.text }]}>{i.concepto}</Text>
+            <Text style={[styles.itemText, { color: colors.text }]}>{format(i.monto)}</Text>
+          </View>
+        ))}
+        <ConceptChart items={ingresos} colors={colors} />
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  content: {
+    padding: 16,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    marginBottom: 8,
+  },
+  item: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 4,
+  },
+  itemText: {
+    fontSize: 16,
+  },
+});

--- a/components/FloatingAddMenu.tsx
+++ b/components/FloatingAddMenu.tsx
@@ -1,0 +1,137 @@
+import { useRef, useState } from 'react';
+import { Animated, View, Pressable, Text, StyleSheet } from 'react-native';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import type { Colors } from '@/context/ThemeContext';
+
+interface Props {
+  colors: Colors;
+  onIngreso: () => void;
+  onDeuda: () => void;
+  onGasto: () => void;
+}
+
+export default function FloatingAddMenu({
+  colors,
+  onIngreso,
+  onDeuda,
+  onGasto,
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const anim = useRef(new Animated.Value(0)).current;
+  const insets = useSafeAreaInsets();
+
+  const toggle = () => {
+    Animated.spring(anim, {
+      toValue: open ? 0 : 1,
+      useNativeDriver: true,
+    }).start();
+    setOpen(!open);
+  };
+
+  const optionStyle = (index: number) => ({
+    opacity: anim,
+    transform: [
+      {
+        translateX: anim.interpolate({
+          inputRange: [0, 1],
+          outputRange: [0, -(64 * (index + 1))],
+        }),
+      },
+      { scale: anim },
+    ],
+  });
+
+  const debtColor = '#d04545';
+
+  return (
+    <View
+      pointerEvents="box-none"
+      style={[styles.wrapper, { bottom: insets.bottom + 16 }]}
+    >
+      <Animated.View style={[styles.option, optionStyle(0)]} pointerEvents={open ? 'auto' : 'none'}>
+        <Pressable
+          style={[styles.optionBtn, { backgroundColor: colors.primary }]}
+          onPress={() => {
+            toggle();
+            onIngreso();
+          }}
+        >
+          <MaterialIcons name="trending-up" size={24} color="#fff" />
+        </Pressable>
+        <Text style={[styles.label, { color: colors.text }]}>Ingreso</Text>
+      </Animated.View>
+
+      <Animated.View style={[styles.option, optionStyle(1)]} pointerEvents={open ? 'auto' : 'none'}>
+        <Pressable
+          style={[styles.optionBtn, { backgroundColor: debtColor }]}
+          onPress={() => {
+            toggle();
+            onDeuda();
+          }}
+        >
+          <MaterialIcons name="trending-down" size={24} color="#fff" />
+        </Pressable>
+        <Text style={[styles.label, { color: colors.text }]}>Deuda</Text>
+      </Animated.View>
+
+      <Animated.View style={[styles.option, optionStyle(2)]} pointerEvents={open ? 'auto' : 'none'}>
+        <Pressable
+          style={[styles.optionBtn, { backgroundColor: colors.accent }]}
+          onPress={() => {
+            toggle();
+            onGasto();
+          }}
+        >
+          <MaterialIcons name="receipt-long" size={24} color="#fff" />
+        </Pressable>
+        <Text style={[styles.label, { color: colors.text }]}>Gasto</Text>
+      </Animated.View>
+
+      <Pressable
+        style={[styles.addButton, { backgroundColor: colors.primary }]}
+        onPress={toggle}
+        accessibilityLabel="Agregar"
+      >
+        <Text style={[styles.addText, { color: '#fff' }]}>{open ? '×' : '＋'}</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    position: 'absolute',
+    right: 16,
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+  },
+  option: {
+    alignItems: 'center',
+    marginRight: 8,
+  },
+  optionBtn: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 4,
+  },
+  label: {
+    fontSize: 12,
+  },
+  addButton: {
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  addText: {
+    fontSize: 32,
+    lineHeight: 32,
+    fontWeight: '600',
+  },
+});

--- a/components/FloatingAddMenu.tsx
+++ b/components/FloatingAddMenu.tsx
@@ -98,13 +98,16 @@ const styles = StyleSheet.create({
     position: 'absolute',
     right: 16,
     flexDirection: 'row-reverse',
-    alignItems: 'flex-end',
+    alignItems: 'center',
     width: '100%',
     zIndex: 10,
   },
   option: {
     alignItems: 'center',
+    justifyContent: 'center',
     marginRight: 8,
+    height: 56,
+    position: 'relative',
   },
   optionBtn: {
     width: 56,
@@ -116,6 +119,8 @@ const styles = StyleSheet.create({
   },
   label: {
     fontSize: 12,
+    position: 'absolute',
+    top: 60,
   },
   addButton: {
     width: 56,

--- a/components/FloatingAddMenu.tsx
+++ b/components/FloatingAddMenu.tsx
@@ -107,12 +107,12 @@ const styles = StyleSheet.create({
     marginRight: 8,
   },
   optionBtn: {
-    width: 48,
-    height: 48,
-    borderRadius: 24,
+    width: 56,
+    height: 56,
+    borderRadius: 28,
     alignItems: 'center',
     justifyContent: 'center',
-    marginBottom: 4,
+    marginBottom: 0,
   },
   label: {
     fontSize: 12,

--- a/components/FloatingAddMenu.tsx
+++ b/components/FloatingAddMenu.tsx
@@ -30,18 +30,10 @@ export default function FloatingAddMenu({
     setOpen(!open);
   };
 
-  const optionStyle = (index: number) => ({
+  const optionStyle = {
     opacity: anim,
-    transform: [
-      {
-        translateX: anim.interpolate({
-          inputRange: [0, 1],
-          outputRange: [0, -(64 * (index + 1))],
-        }),
-      },
-      { scale: anim },
-    ],
-  });
+    transform: [{ scale: anim }],
+  };
 
   const debtColor = '#d04545';
 
@@ -50,7 +42,15 @@ export default function FloatingAddMenu({
       pointerEvents="box-none"
       style={[styles.wrapper, { bottom: insets.bottom + 16 }]}
     >
-      <Animated.View style={[styles.option, optionStyle(0)]} pointerEvents={open ? 'auto' : 'none'}>
+      <Pressable
+        style={[styles.addButton, { backgroundColor: colors.primary }]}
+        onPress={toggle}
+        accessibilityLabel="Agregar"
+      >
+        <Text style={[styles.addText, { color: '#fff' }]}>{open ? '×' : '＋'}</Text>
+      </Pressable>
+
+      <Animated.View style={[styles.option, optionStyle]} pointerEvents={open ? 'auto' : 'none'}>
         <Pressable
           style={[styles.optionBtn, { backgroundColor: colors.primary }]}
           onPress={() => {
@@ -63,7 +63,7 @@ export default function FloatingAddMenu({
         <Text style={[styles.label, { color: colors.text }]}>Ingreso</Text>
       </Animated.View>
 
-      <Animated.View style={[styles.option, optionStyle(1)]} pointerEvents={open ? 'auto' : 'none'}>
+      <Animated.View style={[styles.option, optionStyle]} pointerEvents={open ? 'auto' : 'none'}>
         <Pressable
           style={[styles.optionBtn, { backgroundColor: debtColor }]}
           onPress={() => {
@@ -76,7 +76,7 @@ export default function FloatingAddMenu({
         <Text style={[styles.label, { color: colors.text }]}>Deuda</Text>
       </Animated.View>
 
-      <Animated.View style={[styles.option, optionStyle(2)]} pointerEvents={open ? 'auto' : 'none'}>
+      <Animated.View style={[styles.option, optionStyle]} pointerEvents={open ? 'auto' : 'none'}>
         <Pressable
           style={[styles.optionBtn, { backgroundColor: colors.accent }]}
           onPress={() => {
@@ -89,13 +89,6 @@ export default function FloatingAddMenu({
         <Text style={[styles.label, { color: colors.text }]}>Gasto</Text>
       </Animated.View>
 
-      <Pressable
-        style={[styles.addButton, { backgroundColor: colors.primary }]}
-        onPress={toggle}
-        accessibilityLabel="Agregar"
-      >
-        <Text style={[styles.addText, { color: '#fff' }]}>{open ? '×' : '＋'}</Text>
-      </Pressable>
     </View>
   );
 }
@@ -104,8 +97,10 @@ const styles = StyleSheet.create({
   wrapper: {
     position: 'absolute',
     right: 16,
-    flexDirection: 'row',
+    flexDirection: 'row-reverse',
     alignItems: 'flex-end',
+    width: '100%',
+    zIndex: 10,
   },
   option: {
     alignItems: 'center',

--- a/components/finance/BalanceChart.tsx
+++ b/components/finance/BalanceChart.tsx
@@ -3,49 +3,54 @@ import { useState } from 'react';
 import { PieChart, BarChart } from 'react-native-chart-kit';
 
 import type { Colors } from '@/context/ThemeContext';
+import type { Ingreso, Deuda, Gasto } from '@/hooks/useFinanzas';
 import { useCurrency } from '@/context/CurrencyContext';
 
 interface Props {
-  ingresos: number;
-  deudas: number;
-  gastos: number;
+  ingresos: Ingreso[];
+  deudas: Deuda[];
+  gastos: Gasto[];
   colors: Colors;
   onAddPress?: () => void;
 }
 
 export default function BalanceChart({ ingresos, deudas, gastos, colors, onAddPress }: Props) {
-  const [type, setType] = useState<'pie' | 'bar'>('pie');
+  const [view, setView] = useState<'general' | 'ingresos' | 'deudas' | 'gastos'>('general');
+  const [chart, setChart] = useState<'pie' | 'bar'>('pie');
   const { format } = useCurrency();
   const width = Dimensions.get('window').width - 64;
 
-  const pieData = [
-    {
-      name: 'Ingresos',
-      amount: ingresos,
-      color: colors.primary,
-      legendFontColor: colors.text,
-      legendFontSize: 12,
-    },
-    {
-      name: 'Deudas',
-      amount: deudas,
-      color: '#d04545',
-      legendFontColor: colors.text,
-      legendFontSize: 12,
-    },
-    {
-      name: 'Gastos',
-      amount: gastos,
-      color: colors.accent,
-      legendFontColor: colors.text,
-      legendFontSize: 12,
-    },
-  ];
+  const ingresoTotal = ingresos.reduce((s, i) => s + i.monto, 0);
+  const deudaTotal = deudas.reduce((s, d) => s + d.monto, 0);
+  const gastoTotal = gastos.reduce((s, g) => s + g.monto, 0);
 
-  const barData = {
+  const palette = [colors.primary, colors.accent, '#d04545', '#8b5cf6', '#10b981'];
+
+  const pieDataGeneral = [
+    { name: 'Ingresos', amount: ingresoTotal, color: colors.primary },
+    { name: 'Deudas', amount: deudaTotal, color: '#d04545' },
+    { name: 'Gastos', amount: gastoTotal, color: colors.accent },
+  ].map((d) => ({ ...d, legendFontColor: colors.text, legendFontSize: 12 }));
+
+  const barDataGeneral = {
     labels: ['Ingresos', 'Deudas', 'Gastos'],
-    datasets: [{ data: [ingresos, deudas, gastos] }],
-  };
+    datasets: [{ data: [ingresoTotal, deudaTotal, gastoTotal] }],
+  } as const;
+
+  const selectedItems = view === 'ingresos' ? ingresos : view === 'deudas' ? deudas : gastos;
+
+  const pieDataItems = selectedItems.map((i, idx) => ({
+    name: i.concepto,
+    amount: i.monto,
+    color: palette[idx % palette.length],
+    legendFontColor: colors.text,
+    legendFontSize: 12,
+  }));
+
+  const barDataItems = {
+    labels: selectedItems.map((i) => i.concepto),
+    datasets: [{ data: selectedItems.map((i) => i.monto) }],
+  } as const;
 
   const chartConfig = {
     backgroundColor: colors.surface,
@@ -55,24 +60,32 @@ export default function BalanceChart({ ingresos, deudas, gastos, colors, onAddPr
     labelColor: () => colors.text,
   } as const;
 
+  const showPie = view === 'general' || chart === 'pie';
+
   return (
     <View style={[styles.container, { backgroundColor: colors.surface }]}>
-      {onAddPress && (
-        <Pressable style={styles.addButton} onPress={onAddPress} accessibilityLabel="Agregar dato">
-          <Text style={[styles.addText, { color: colors.primary }]}>＋</Text>
-        </Pressable>
-      )}
       <View style={styles.menu}>
-        <Pressable onPress={() => setType('pie')}>
-          <Text style={[styles.menuItem, { color: type === 'pie' ? colors.primary : colors.text }]}>🍰</Text>
-        </Pressable>
-        <Pressable onPress={() => setType('bar')}>
-          <Text style={[styles.menuItem, { color: type === 'bar' ? colors.primary : colors.text }]}>📊</Text>
-        </Pressable>
+        {(['general', 'ingresos', 'deudas', 'gastos'] as const).map((m) => (
+          <Pressable key={m} onPress={() => { setView(m); setChart('pie'); }}>
+            <Text style={[styles.menuItem, { color: view === m ? colors.primary : colors.text }]}>
+              {m.charAt(0).toUpperCase() + m.slice(1)}
+            </Text>
+          </Pressable>
+        ))}
       </View>
-      {type === 'pie' ? (
+      {view !== 'general' && (
+        <View style={styles.submenu}>
+          <Pressable onPress={() => setChart('pie')}>
+            <Text style={[styles.menuItem, { color: chart === 'pie' ? colors.primary : colors.text }]}>Pie</Text>
+          </Pressable>
+          <Pressable onPress={() => setChart('bar')}>
+            <Text style={[styles.menuItem, { color: chart === 'bar' ? colors.primary : colors.text }]}>Barras</Text>
+          </Pressable>
+        </View>
+      )}
+      {showPie ? (
         <PieChart
-          data={pieData}
+          data={view === 'general' ? pieDataGeneral : pieDataItems}
           width={width}
           height={220}
           accessor="amount"
@@ -82,7 +95,7 @@ export default function BalanceChart({ ingresos, deudas, gastos, colors, onAddPr
         />
       ) : (
         <BarChart
-          data={barData}
+          data={view === 'general' ? barDataGeneral : barDataItems}
           width={width}
           height={220}
           chartConfig={chartConfig}
@@ -91,9 +104,22 @@ export default function BalanceChart({ ingresos, deudas, gastos, colors, onAddPr
           showValuesOnTopOfBars
         />
       )}
-      <Text style={[styles.text, { color: colors.text }]}>Ingresos: {format(ingresos)}</Text>
-      <Text style={[styles.text, { color: colors.text }]}>Deudas: {format(deudas)}</Text>
-      <Text style={[styles.text, { color: colors.text }]}>Gastos: {format(gastos)}</Text>
+      {view === 'general' && (
+        <>
+          <Text style={[styles.total, { color: colors.text }]}>Ingresos: {format(ingresoTotal)}</Text>
+          <Text style={[styles.total, { color: colors.text }]}>Deudas: {format(deudaTotal)}</Text>
+          <Text style={[styles.total, { color: colors.text }]}>Gastos: {format(gastoTotal)}</Text>
+        </>
+      )}
+      {onAddPress && (
+        <Pressable
+          style={[styles.addButton, { backgroundColor: colors.primary }]}
+          onPress={onAddPress}
+          accessibilityLabel="Agregar dato"
+        >
+          <Text style={[styles.addText, { color: '#fff' }]}>＋</Text>
+        </Pressable>
+      )}
     </View>
   );
 }
@@ -102,29 +128,40 @@ const styles = StyleSheet.create({
   container: {
     padding: 16,
     borderRadius: 8,
-    alignItems: 'center',
     marginBottom: 16,
+    alignItems: 'center',
     position: 'relative',
-  },
-  text: {
-    fontWeight: 'bold',
-    marginBottom: 8,
-  },
-  addButton: {
-    position: 'absolute',
-    top: 8,
-    right: 8,
-  },
-  addText: {
-    fontSize: 24,
-    fontWeight: '600',
   },
   menu: {
     flexDirection: 'row',
     gap: 12,
     marginBottom: 8,
   },
+  submenu: {
+    flexDirection: 'row',
+    gap: 12,
+    marginBottom: 8,
+  },
   menuItem: {
-    fontSize: 18,
+    fontSize: 16,
+    fontWeight: '500',
+  },
+  total: {
+    fontWeight: 'bold',
+    marginTop: 8,
+  },
+  addButton: {
+    position: 'absolute',
+    bottom: 8,
+    right: 8,
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  addText: {
+    fontSize: 24,
+    fontWeight: '600',
   },
 });

--- a/components/finance/BalanceChart.tsx
+++ b/components/finance/BalanceChart.tsx
@@ -11,10 +11,9 @@ interface Props {
   deudas: Deuda[];
   gastos: Gasto[];
   colors: Colors;
-  onAddPress?: () => void;
 }
 
-export default function BalanceChart({ ingresos, deudas, gastos, colors, onAddPress }: Props) {
+export default function BalanceChart({ ingresos, deudas, gastos, colors }: Props) {
   const [view, setView] = useState<'general' | 'ingresos' | 'deudas' | 'gastos'>('general');
   const [chart, setChart] = useState<'pie' | 'bar'>('pie');
   const { format } = useCurrency();
@@ -111,15 +110,6 @@ export default function BalanceChart({ ingresos, deudas, gastos, colors, onAddPr
           <Text style={[styles.total, { color: colors.text }]}>Gastos: {format(gastoTotal)}</Text>
         </>
       )}
-      {onAddPress && (
-        <Pressable
-          style={[styles.addButton, { backgroundColor: colors.primary }]}
-          onPress={onAddPress}
-          accessibilityLabel="Agregar dato"
-        >
-          <Text style={[styles.addText, { color: '#fff' }]}>＋</Text>
-        </Pressable>
-      )}
     </View>
   );
 }
@@ -149,19 +139,5 @@ const styles = StyleSheet.create({
   total: {
     fontWeight: 'bold',
     marginTop: 8,
-  },
-  addButton: {
-    position: 'absolute',
-    bottom: 8,
-    right: 8,
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  addText: {
-    fontSize: 24,
-    fontWeight: '600',
   },
 });

--- a/components/finance/ConceptChart.tsx
+++ b/components/finance/ConceptChart.tsx
@@ -48,10 +48,10 @@ export default function ConceptChart({ items, colors }: Props) {
     <View style={[styles.container, { backgroundColor: colors.surface }]}>
       <View style={styles.menu}>
         <Pressable onPress={() => setType('pie')}>
-          <Text style={[styles.menuItem, { color: type === 'pie' ? colors.primary : colors.text }]}>🍰</Text>
+          <Text style={[styles.menuItem, { color: type === 'pie' ? colors.primary : colors.text }]}>Pie</Text>
         </Pressable>
         <Pressable onPress={() => setType('bar')}>
-          <Text style={[styles.menuItem, { color: type === 'bar' ? colors.primary : colors.text }]}>📊</Text>
+          <Text style={[styles.menuItem, { color: type === 'bar' ? colors.primary : colors.text }]}>Barras</Text>
         </Pressable>
       </View>
       {items.length === 0 ? (

--- a/components/finance/ConceptChart.tsx
+++ b/components/finance/ConceptChart.tsx
@@ -5,46 +5,33 @@ import { PieChart, BarChart } from 'react-native-chart-kit';
 import type { Colors } from '@/context/ThemeContext';
 import { useCurrency } from '@/context/CurrencyContext';
 
-interface Props {
-  ingresos: number;
-  deudas: number;
-  gastos: number;
-  colors: Colors;
-  onAddPress?: () => void;
+export interface ConceptItem {
+  concepto: string;
+  monto: number;
 }
 
-export default function BalanceChart({ ingresos, deudas, gastos, colors, onAddPress }: Props) {
+interface Props {
+  items: ConceptItem[];
+  colors: Colors;
+}
+
+export default function ConceptChart({ items, colors }: Props) {
   const [type, setType] = useState<'pie' | 'bar'>('pie');
   const { format } = useCurrency();
   const width = Dimensions.get('window').width - 64;
+  const palette = [colors.primary, colors.accent, '#d04545', '#8b5cf6', '#10b981'];
 
-  const pieData = [
-    {
-      name: 'Ingresos',
-      amount: ingresos,
-      color: colors.primary,
-      legendFontColor: colors.text,
-      legendFontSize: 12,
-    },
-    {
-      name: 'Deudas',
-      amount: deudas,
-      color: '#d04545',
-      legendFontColor: colors.text,
-      legendFontSize: 12,
-    },
-    {
-      name: 'Gastos',
-      amount: gastos,
-      color: colors.accent,
-      legendFontColor: colors.text,
-      legendFontSize: 12,
-    },
-  ];
+  const pieData = items.map((i, idx) => ({
+    name: i.concepto,
+    amount: i.monto,
+    color: palette[idx % palette.length],
+    legendFontColor: colors.text,
+    legendFontSize: 12,
+  }));
 
   const barData = {
-    labels: ['Ingresos', 'Deudas', 'Gastos'],
-    datasets: [{ data: [ingresos, deudas, gastos] }],
+    labels: items.map((i) => i.concepto),
+    datasets: [{ data: items.map((i) => i.monto) }],
   };
 
   const chartConfig = {
@@ -55,13 +42,10 @@ export default function BalanceChart({ ingresos, deudas, gastos, colors, onAddPr
     labelColor: () => colors.text,
   } as const;
 
+  const total = items.reduce((sum, i) => sum + i.monto, 0);
+
   return (
     <View style={[styles.container, { backgroundColor: colors.surface }]}>
-      {onAddPress && (
-        <Pressable style={styles.addButton} onPress={onAddPress} accessibilityLabel="Agregar dato">
-          <Text style={[styles.addText, { color: colors.primary }]}>＋</Text>
-        </Pressable>
-      )}
       <View style={styles.menu}>
         <Pressable onPress={() => setType('pie')}>
           <Text style={[styles.menuItem, { color: type === 'pie' ? colors.primary : colors.text }]}>🍰</Text>
@@ -70,7 +54,9 @@ export default function BalanceChart({ ingresos, deudas, gastos, colors, onAddPr
           <Text style={[styles.menuItem, { color: type === 'bar' ? colors.primary : colors.text }]}>📊</Text>
         </Pressable>
       </View>
-      {type === 'pie' ? (
+      {items.length === 0 ? (
+        <Text style={{ color: colors.text }}>Sin datos</Text>
+      ) : type === 'pie' ? (
         <PieChart
           data={pieData}
           width={width}
@@ -91,9 +77,7 @@ export default function BalanceChart({ ingresos, deudas, gastos, colors, onAddPr
           showValuesOnTopOfBars
         />
       )}
-      <Text style={[styles.text, { color: colors.text }]}>Ingresos: {format(ingresos)}</Text>
-      <Text style={[styles.text, { color: colors.text }]}>Deudas: {format(deudas)}</Text>
-      <Text style={[styles.text, { color: colors.text }]}>Gastos: {format(gastos)}</Text>
+      <Text style={[styles.total, { color: colors.text }]}>Total: {format(total)}</Text>
     </View>
   );
 }
@@ -102,22 +86,8 @@ const styles = StyleSheet.create({
   container: {
     padding: 16,
     borderRadius: 8,
-    alignItems: 'center',
     marginBottom: 16,
-    position: 'relative',
-  },
-  text: {
-    fontWeight: 'bold',
-    marginBottom: 8,
-  },
-  addButton: {
-    position: 'absolute',
-    top: 8,
-    right: 8,
-  },
-  addText: {
-    fontSize: 24,
-    fontWeight: '600',
+    alignItems: 'center',
   },
   menu: {
     flexDirection: 'row',
@@ -126,5 +96,9 @@ const styles = StyleSheet.create({
   },
   menuItem: {
     fontSize: 18,
+  },
+  total: {
+    marginTop: 8,
+    fontWeight: 'bold',
   },
 });

--- a/components/finance/DebtSection.tsx
+++ b/components/finance/DebtSection.tsx
@@ -1,7 +1,6 @@
-import { useState, useEffect } from 'react';
-import { View, Text, TextInput, StyleSheet, Modal, Pressable, Switch } from 'react-native';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
+import { useRouter } from 'expo-router';
 
-import AppButton from '../AppButton';
 import { useCurrency } from '@/context/CurrencyContext';
 
 import type { Deuda } from '@/hooks/useFinanzas';
@@ -9,57 +8,18 @@ import type { Colors } from '@/context/ThemeContext';
 
 interface Props {
   deudas: Deuda[];
-  onAdd: (deuda: Deuda) => void;
   colors: Colors;
-  autoOpen?: boolean;
 }
 
-export default function DebtSection({ deudas, onAdd, colors, autoOpen = false }: Props) {
-  const [concepto, setConcepto] = useState('');
-  const [monto, setMonto] = useState('');
-  const [meses, setMeses] = useState('');
-  const [indefinido, setIndefinido] = useState(true);
-  const [tieneAumento, setTieneAumento] = useState(false);
-  const [aumento, setAumento] = useState('');
-  const [aumentoMeses, setAumentoMeses] = useState('');
-  const [showModal, setShowModal] = useState(autoOpen);
+export default function DebtSection({ deudas, colors }: Props) {
   const { format } = useCurrency();
-
-  useEffect(() => {
-    if (autoOpen) {
-      setShowModal(true);
-    }
-  }, [autoOpen]);
-
-  const handleAdd = () => {
-    const montoNum = parseFloat(monto);
-    const mesesNum = parseInt(meses, 10);
-    const aumentoNum = parseFloat(aumento);
-    const aumentoMesNum = parseInt(aumentoMeses, 10);
-    if (!concepto || isNaN(montoNum)) return;
-    onAdd({
-      concepto,
-      monto: montoNum,
-      meses: indefinido || isNaN(mesesNum) ? 0 : mesesNum,
-      aumento: tieneAumento && !isNaN(aumentoNum) ? aumentoNum : undefined,
-      aumentoFrecuencia:
-        tieneAumento && !isNaN(aumentoMesNum) ? aumentoMesNum : undefined,
-    });
-    setConcepto('');
-    setMonto('');
-    setMeses('');
-    setAumento('');
-    setAumentoMeses('');
-    setIndefinido(true);
-    setTieneAumento(false);
-    setShowModal(false);
-  };
+  const router = useRouter();
 
   return (
     <View style={[styles.section, { backgroundColor: colors.surface }]}>
       <View style={styles.header}>
         <Text style={[styles.title, { color: colors.text }]}>Deudas</Text>
-        <Pressable onPress={() => setShowModal(true)}>
+        <Pressable onPress={() => router.push('/(modals)/deuda')}>
           <Text style={[styles.add, { color: colors.primary }]}>＋</Text>
         </Pressable>
       </View>
@@ -70,84 +30,6 @@ export default function DebtSection({ deudas, onAdd, colors, autoOpen = false }:
           </Text>
         ))}
       </View>
-
-      <Modal transparent animationType="slide" visible={showModal}>
-        <View style={styles.modalBackdrop}>
-          <View style={[styles.modalContent, { backgroundColor: colors.surface }]}>
-            <Text style={[styles.modalTitle, { color: colors.text }]}>Nueva Deuda</Text>
-            <View style={styles.group}>
-              <Text style={{ color: colors.text }}>Concepto</Text>
-              <TextInput
-                value={concepto}
-                onChangeText={setConcepto}
-                style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
-              />
-            </View>
-            <View style={styles.group}>
-              <Text style={{ color: colors.text }}>Monto</Text>
-              <TextInput
-                value={monto}
-                onChangeText={setMonto}
-                keyboardType="numeric"
-                style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
-              />
-            </View>
-            <View style={styles.group}>
-              <View style={styles.switchRow}>
-                <Text style={{ color: colors.text }}>Indefinido</Text>
-                <Switch value={indefinido} onValueChange={setIndefinido} />
-              </View>
-            </View>
-            {!indefinido && (
-              <View style={styles.group}>
-                <Text style={{ color: colors.text }}>Meses</Text>
-                <TextInput
-                  value={meses}
-                  onChangeText={setMeses}
-                  keyboardType="numeric"
-                  style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
-                />
-              </View>
-            )}
-            <View style={styles.group}>
-              <View style={styles.switchRow}>
-                <Text style={{ color: colors.text }}>Aumento pactado</Text>
-                <Switch value={tieneAumento} onValueChange={setTieneAumento} />
-              </View>
-            </View>
-            {tieneAumento && (
-              <>
-                <View style={styles.group}>
-                  <Text style={{ color: colors.text }}>Porcentaje de aumento</Text>
-                  <TextInput
-                    value={aumento}
-                    onChangeText={setAumento}
-                    keyboardType="numeric"
-                    style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
-                  />
-                </View>
-                <View style={styles.group}>
-                  <Text style={{ color: colors.text }}>Cada cuantos meses</Text>
-                  <TextInput
-                    value={aumentoMeses}
-                    onChangeText={setAumentoMeses}
-                    keyboardType="numeric"
-                    style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
-                  />
-                </View>
-              </>
-            )}
-            <AppButton title="Guardar" color={colors.primary} onPress={handleAdd} />
-            <AppButton
-              title="Cancelar"
-              color={colors.accent}
-              onPress={() => {
-                setShowModal(false);
-              }}
-            />
-          </View>
-        </View>
-      </Modal>
     </View>
   );
 }
@@ -163,15 +45,6 @@ const styles = StyleSheet.create({
     fontSize: 18,
     marginBottom: 8,
   },
-  group: {
-    marginBottom: 12,
-  },
-  input: {
-    borderWidth: 1,
-    borderRadius: 6,
-    padding: 8,
-    marginTop: 4,
-  },
   list: {
     marginTop: 8,
   },
@@ -185,24 +58,5 @@ const styles = StyleSheet.create({
     fontSize: 24,
     fontWeight: '600',
   },
-  modalBackdrop: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.5)',
-    justifyContent: 'center',
-    padding: 16,
-  },
-  modalContent: {
-    borderRadius: 8,
-    padding: 16,
-  },
-  modalTitle: {
-    fontSize: 18,
-    fontWeight: 'bold',
-    marginBottom: 12,
-  },
-  switchRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
+
 });

--- a/components/finance/DebtSection.tsx
+++ b/components/finance/DebtSection.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { View, Text, TextInput, StyleSheet, Modal, Pressable, Switch } from 'react-native';
 
 import AppButton from '../AppButton';
 import { useCurrency } from '@/context/CurrencyContext';
+import { useRouter } from 'expo-router';
 
 import type { Deuda } from '@/hooks/useFinanzas';
 import type { Colors } from '@/context/ThemeContext';
@@ -24,6 +25,13 @@ export default function DebtSection({ deudas, onAdd, colors, autoOpen = false }:
   const [aumentoMeses, setAumentoMeses] = useState('');
   const [showModal, setShowModal] = useState(autoOpen);
   const { format } = useCurrency();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (autoOpen) {
+      setShowModal(true);
+    }
+  }, [autoOpen]);
 
   const handleAdd = () => {
     const montoNum = parseFloat(monto);
@@ -47,6 +55,7 @@ export default function DebtSection({ deudas, onAdd, colors, autoOpen = false }:
     setIndefinido(true);
     setTieneAumento(false);
     setShowModal(false);
+    router.setParams({ add: undefined });
   };
 
   return (
@@ -132,7 +141,14 @@ export default function DebtSection({ deudas, onAdd, colors, autoOpen = false }:
               </>
             )}
             <AppButton title="Guardar" color={colors.primary} onPress={handleAdd} />
-            <AppButton title="Cancelar" color={colors.accent} onPress={() => setShowModal(false)} />
+            <AppButton
+              title="Cancelar"
+              color={colors.accent}
+              onPress={() => {
+                setShowModal(false);
+                router.setParams({ add: undefined });
+              }}
+            />
           </View>
         </View>
       </Modal>

--- a/components/finance/DebtSection.tsx
+++ b/components/finance/DebtSection.tsx
@@ -3,7 +3,6 @@ import { View, Text, TextInput, StyleSheet, Modal, Pressable, Switch } from 'rea
 
 import AppButton from '../AppButton';
 import { useCurrency } from '@/context/CurrencyContext';
-import { useRouter } from 'expo-router';
 
 import type { Deuda } from '@/hooks/useFinanzas';
 import type { Colors } from '@/context/ThemeContext';
@@ -25,7 +24,6 @@ export default function DebtSection({ deudas, onAdd, colors, autoOpen = false }:
   const [aumentoMeses, setAumentoMeses] = useState('');
   const [showModal, setShowModal] = useState(autoOpen);
   const { format } = useCurrency();
-  const router = useRouter();
 
   useEffect(() => {
     if (autoOpen) {
@@ -55,7 +53,6 @@ export default function DebtSection({ deudas, onAdd, colors, autoOpen = false }:
     setIndefinido(true);
     setTieneAumento(false);
     setShowModal(false);
-    router.setParams({ add: undefined });
   };
 
   return (
@@ -146,7 +143,6 @@ export default function DebtSection({ deudas, onAdd, colors, autoOpen = false }:
               color={colors.accent}
               onPress={() => {
                 setShowModal(false);
-                router.setParams({ add: undefined });
               }}
             />
           </View>

--- a/components/finance/ExpenseSection.tsx
+++ b/components/finance/ExpenseSection.tsx
@@ -6,7 +6,6 @@ import AppButton from '../AppButton';
 import type { Gasto } from '@/hooks/useFinanzas';
 import type { Colors } from '@/context/ThemeContext';
 import { useCurrency } from '@/context/CurrencyContext';
-import { useRouter } from 'expo-router';
 
 interface Props {
   gastos: Gasto[];
@@ -20,7 +19,6 @@ export default function ExpenseSection({ gastos, onAdd, colors, autoOpen = false
   const [monto, setMonto] = useState('');
   const [showModal, setShowModal] = useState(autoOpen);
   const { format } = useCurrency();
-  const router = useRouter();
 
   useEffect(() => {
     if (autoOpen) {
@@ -35,7 +33,6 @@ export default function ExpenseSection({ gastos, onAdd, colors, autoOpen = false
     setConcepto('');
     setMonto('');
     setShowModal(false);
-    router.setParams({ add: undefined });
   };
 
   return (
@@ -81,7 +78,6 @@ export default function ExpenseSection({ gastos, onAdd, colors, autoOpen = false
               color={colors.accent}
               onPress={() => {
                 setShowModal(false);
-                router.setParams({ add: undefined });
               }}
             />
           </View>

--- a/components/finance/ExpenseSection.tsx
+++ b/components/finance/ExpenseSection.tsx
@@ -1,7 +1,5 @@
-import { useState, useEffect } from 'react';
-import { View, Text, TextInput, StyleSheet, Modal, Pressable } from 'react-native';
-
-import AppButton from '../AppButton';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
+import { useRouter } from 'expo-router';
 
 import type { Gasto } from '@/hooks/useFinanzas';
 import type { Colors } from '@/context/ThemeContext';
@@ -9,37 +7,18 @@ import { useCurrency } from '@/context/CurrencyContext';
 
 interface Props {
   gastos: Gasto[];
-  onAdd: (gasto: Gasto) => void;
   colors: Colors;
-  autoOpen?: boolean;
 }
 
-export default function ExpenseSection({ gastos, onAdd, colors, autoOpen = false }: Props) {
-  const [concepto, setConcepto] = useState('');
-  const [monto, setMonto] = useState('');
-  const [showModal, setShowModal] = useState(autoOpen);
+export default function ExpenseSection({ gastos, colors }: Props) {
   const { format } = useCurrency();
-
-  useEffect(() => {
-    if (autoOpen) {
-      setShowModal(true);
-    }
-  }, [autoOpen]);
-
-  const handleAdd = () => {
-    const montoNum = parseFloat(monto);
-    if (!concepto || isNaN(montoNum)) return;
-    onAdd({ concepto, monto: montoNum });
-    setConcepto('');
-    setMonto('');
-    setShowModal(false);
-  };
+  const router = useRouter();
 
   return (
     <View style={[styles.section, { backgroundColor: colors.surface }]}>
       <View style={styles.header}>
         <Text style={[styles.title, { color: colors.text }]}>Gastos Diarios</Text>
-        <Pressable onPress={() => setShowModal(true)}>
+        <Pressable onPress={() => router.push('/(modals)/gasto')}>
           <Text style={[styles.add, { color: colors.primary }]}>＋</Text>
         </Pressable>
       </View>
@@ -50,39 +29,6 @@ export default function ExpenseSection({ gastos, onAdd, colors, autoOpen = false
           </Text>
         ))}
       </View>
-
-      <Modal transparent animationType="slide" visible={showModal}>
-        <View style={styles.modalBackdrop}>
-          <View style={[styles.modalContent, { backgroundColor: colors.surface }]}>
-            <Text style={[styles.modalTitle, { color: colors.text }]}>Nuevo Gasto</Text>
-            <View style={styles.group}>
-              <Text style={{ color: colors.text }}>Concepto</Text>
-              <TextInput
-                value={concepto}
-                onChangeText={setConcepto}
-                style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
-              />
-            </View>
-            <View style={styles.group}>
-              <Text style={{ color: colors.text }}>Monto</Text>
-              <TextInput
-                value={monto}
-                onChangeText={setMonto}
-                keyboardType="numeric"
-                style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
-              />
-            </View>
-            <AppButton title="Guardar" color={colors.primary} onPress={handleAdd} />
-            <AppButton
-              title="Cancelar"
-              color={colors.accent}
-              onPress={() => {
-                setShowModal(false);
-              }}
-            />
-          </View>
-        </View>
-      </Modal>
     </View>
   );
 }
@@ -98,15 +44,6 @@ const styles = StyleSheet.create({
     fontSize: 18,
     marginBottom: 8,
   },
-  group: {
-    marginBottom: 12,
-  },
-  input: {
-    borderWidth: 1,
-    borderRadius: 6,
-    padding: 8,
-    marginTop: 4,
-  },
   list: {
     marginTop: 8,
   },
@@ -120,19 +57,5 @@ const styles = StyleSheet.create({
     fontSize: 24,
     fontWeight: '600',
   },
-  modalBackdrop: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.5)',
-    justifyContent: 'center',
-    padding: 16,
-  },
-  modalContent: {
-    borderRadius: 8,
-    padding: 16,
-  },
-  modalTitle: {
-    fontSize: 18,
-    fontWeight: 'bold',
-    marginBottom: 12,
-  },
+  
 });

--- a/components/finance/ExpenseSection.tsx
+++ b/components/finance/ExpenseSection.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { View, Text, TextInput, StyleSheet, Modal, Pressable } from 'react-native';
 
 import AppButton from '../AppButton';
@@ -6,6 +6,7 @@ import AppButton from '../AppButton';
 import type { Gasto } from '@/hooks/useFinanzas';
 import type { Colors } from '@/context/ThemeContext';
 import { useCurrency } from '@/context/CurrencyContext';
+import { useRouter } from 'expo-router';
 
 interface Props {
   gastos: Gasto[];
@@ -19,6 +20,13 @@ export default function ExpenseSection({ gastos, onAdd, colors, autoOpen = false
   const [monto, setMonto] = useState('');
   const [showModal, setShowModal] = useState(autoOpen);
   const { format } = useCurrency();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (autoOpen) {
+      setShowModal(true);
+    }
+  }, [autoOpen]);
 
   const handleAdd = () => {
     const montoNum = parseFloat(monto);
@@ -27,6 +35,7 @@ export default function ExpenseSection({ gastos, onAdd, colors, autoOpen = false
     setConcepto('');
     setMonto('');
     setShowModal(false);
+    router.setParams({ add: undefined });
   };
 
   return (
@@ -67,7 +76,14 @@ export default function ExpenseSection({ gastos, onAdd, colors, autoOpen = false
               />
             </View>
             <AppButton title="Guardar" color={colors.primary} onPress={handleAdd} />
-            <AppButton title="Cancelar" color={colors.accent} onPress={() => setShowModal(false)} />
+            <AppButton
+              title="Cancelar"
+              color={colors.accent}
+              onPress={() => {
+                setShowModal(false);
+                router.setParams({ add: undefined });
+              }}
+            />
           </View>
         </View>
       </Modal>

--- a/components/finance/IncomeSection.tsx
+++ b/components/finance/IncomeSection.tsx
@@ -3,7 +3,6 @@ import { View, Text, TextInput, StyleSheet, Modal, Pressable, Switch } from 'rea
 
 import AppButton from '../AppButton';
 import { useCurrency } from '@/context/CurrencyContext';
-import { useRouter } from 'expo-router';
 
 import type { Ingreso } from '@/hooks/useFinanzas';
 import type { Colors } from '@/context/ThemeContext';
@@ -25,7 +24,6 @@ export default function IncomeSection({ ingresos, onAdd, colors, autoOpen = fals
   const [aumentoMeses, setAumentoMeses] = useState('');
   const [showModal, setShowModal] = useState(autoOpen);
   const { format } = useCurrency();
-  const router = useRouter();
 
   useEffect(() => {
     if (autoOpen) {
@@ -55,7 +53,6 @@ export default function IncomeSection({ ingresos, onAdd, colors, autoOpen = fals
     setIndefinido(true);
     setTieneAumento(false);
     setShowModal(false);
-    router.setParams({ add: undefined });
   };
 
   return (
@@ -146,7 +143,6 @@ export default function IncomeSection({ ingresos, onAdd, colors, autoOpen = fals
               color={colors.accent}
               onPress={() => {
                 setShowModal(false);
-                router.setParams({ add: undefined });
               }}
             />
           </View>

--- a/components/finance/IncomeSection.tsx
+++ b/components/finance/IncomeSection.tsx
@@ -1,7 +1,6 @@
-import { useState, useEffect } from 'react';
-import { View, Text, TextInput, StyleSheet, Modal, Pressable, Switch } from 'react-native';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
+import { useRouter } from 'expo-router';
 
-import AppButton from '../AppButton';
 import { useCurrency } from '@/context/CurrencyContext';
 
 import type { Ingreso } from '@/hooks/useFinanzas';
@@ -9,57 +8,18 @@ import type { Colors } from '@/context/ThemeContext';
 
 interface Props {
   ingresos: Ingreso[];
-  onAdd: (ingreso: Ingreso) => void;
   colors: Colors;
-  autoOpen?: boolean;
 }
 
-export default function IncomeSection({ ingresos, onAdd, colors, autoOpen = false }: Props) {
-  const [concepto, setConcepto] = useState('');
-  const [monto, setMonto] = useState('');
-  const [meses, setMeses] = useState('');
-  const [indefinido, setIndefinido] = useState(true);
-  const [tieneAumento, setTieneAumento] = useState(false);
-  const [aumento, setAumento] = useState('');
-  const [aumentoMeses, setAumentoMeses] = useState('');
-  const [showModal, setShowModal] = useState(autoOpen);
+export default function IncomeSection({ ingresos, colors }: Props) {
   const { format } = useCurrency();
-
-  useEffect(() => {
-    if (autoOpen) {
-      setShowModal(true);
-    }
-  }, [autoOpen]);
-
-  const handleAdd = () => {
-    const montoNum = parseFloat(monto);
-    const mesesNum = parseInt(meses, 10);
-    const aumentoNum = parseFloat(aumento);
-    const aumentoMesNum = parseInt(aumentoMeses, 10);
-    if (!concepto || isNaN(montoNum)) return;
-    onAdd({
-      concepto,
-      monto: montoNum,
-      meses: indefinido || isNaN(mesesNum) ? 0 : mesesNum,
-      aumento: tieneAumento && !isNaN(aumentoNum) ? aumentoNum : undefined,
-      aumentoFrecuencia:
-        tieneAumento && !isNaN(aumentoMesNum) ? aumentoMesNum : undefined,
-    });
-    setConcepto('');
-    setMonto('');
-    setMeses('');
-    setAumento('');
-    setAumentoMeses('');
-    setIndefinido(true);
-    setTieneAumento(false);
-    setShowModal(false);
-  };
+  const router = useRouter();
 
   return (
     <View style={[styles.section, { backgroundColor: colors.surface }]}>
       <View style={styles.header}>
         <Text style={[styles.title, { color: colors.text }]}>Ingresos</Text>
-        <Pressable onPress={() => setShowModal(true)}>
+        <Pressable onPress={() => router.push('/(modals)/ingreso')}>
           <Text style={[styles.add, { color: colors.primary }]}>＋</Text>
         </Pressable>
       </View>
@@ -70,84 +30,6 @@ export default function IncomeSection({ ingresos, onAdd, colors, autoOpen = fals
           </Text>
         ))}
       </View>
-
-      <Modal transparent animationType="slide" visible={showModal}>
-        <View style={styles.modalBackdrop}>
-          <View style={[styles.modalContent, { backgroundColor: colors.surface }]}>
-            <Text style={[styles.modalTitle, { color: colors.text }]}>Nuevo Ingreso</Text>
-            <View style={styles.group}>
-              <Text style={{ color: colors.text }}>Concepto</Text>
-              <TextInput
-                value={concepto}
-                onChangeText={setConcepto}
-                style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
-              />
-            </View>
-            <View style={styles.group}>
-              <Text style={{ color: colors.text }}>Monto</Text>
-              <TextInput
-                value={monto}
-                onChangeText={setMonto}
-                keyboardType="numeric"
-                style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
-              />
-            </View>
-            <View style={styles.group}>
-              <View style={styles.switchRow}>
-                <Text style={{ color: colors.text }}>Indefinido</Text>
-                <Switch value={indefinido} onValueChange={setIndefinido} />
-              </View>
-            </View>
-            {!indefinido && (
-              <View style={styles.group}>
-                <Text style={{ color: colors.text }}>Meses</Text>
-                <TextInput
-                  value={meses}
-                  onChangeText={setMeses}
-                  keyboardType="numeric"
-                  style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
-                />
-              </View>
-            )}
-            <View style={styles.group}>
-              <View style={styles.switchRow}>
-                <Text style={{ color: colors.text }}>Aumento pactado</Text>
-                <Switch value={tieneAumento} onValueChange={setTieneAumento} />
-              </View>
-            </View>
-            {tieneAumento && (
-              <>
-                <View style={styles.group}>
-                  <Text style={{ color: colors.text }}>Porcentaje de aumento</Text>
-                  <TextInput
-                    value={aumento}
-                    onChangeText={setAumento}
-                    keyboardType="numeric"
-                    style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
-                  />
-                </View>
-                <View style={styles.group}>
-                  <Text style={{ color: colors.text }}>Cada cuantos meses</Text>
-                  <TextInput
-                    value={aumentoMeses}
-                    onChangeText={setAumentoMeses}
-                    keyboardType="numeric"
-                    style={[styles.input, { color: colors.text, borderColor: colors.primary }]}
-                  />
-                </View>
-              </>
-            )}
-            <AppButton title="Guardar" color={colors.primary} onPress={handleAdd} />
-            <AppButton
-              title="Cancelar"
-              color={colors.accent}
-              onPress={() => {
-                setShowModal(false);
-              }}
-            />
-          </View>
-        </View>
-      </Modal>
     </View>
   );
 }
@@ -163,15 +45,6 @@ const styles = StyleSheet.create({
     fontSize: 18,
     marginBottom: 8,
   },
-  group: {
-    marginBottom: 12,
-  },
-  input: {
-    borderWidth: 1,
-    borderRadius: 6,
-    padding: 8,
-    marginTop: 4,
-  },
   list: {
     marginTop: 8,
   },
@@ -185,24 +58,5 @@ const styles = StyleSheet.create({
     fontSize: 24,
     fontWeight: '600',
   },
-  modalBackdrop: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.5)',
-    justifyContent: 'center',
-    padding: 16,
-  },
-  modalContent: {
-    borderRadius: 8,
-    padding: 16,
-  },
-  modalTitle: {
-    fontSize: 18,
-    fontWeight: 'bold',
-    marginBottom: 12,
-  },
-  switchRow: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
+  
 });

--- a/components/finance/IncomeSection.tsx
+++ b/components/finance/IncomeSection.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { View, Text, TextInput, StyleSheet, Modal, Pressable, Switch } from 'react-native';
 
 import AppButton from '../AppButton';
 import { useCurrency } from '@/context/CurrencyContext';
+import { useRouter } from 'expo-router';
 
 import type { Ingreso } from '@/hooks/useFinanzas';
 import type { Colors } from '@/context/ThemeContext';
@@ -24,6 +25,13 @@ export default function IncomeSection({ ingresos, onAdd, colors, autoOpen = fals
   const [aumentoMeses, setAumentoMeses] = useState('');
   const [showModal, setShowModal] = useState(autoOpen);
   const { format } = useCurrency();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (autoOpen) {
+      setShowModal(true);
+    }
+  }, [autoOpen]);
 
   const handleAdd = () => {
     const montoNum = parseFloat(monto);
@@ -47,6 +55,7 @@ export default function IncomeSection({ ingresos, onAdd, colors, autoOpen = fals
     setIndefinido(true);
     setTieneAumento(false);
     setShowModal(false);
+    router.setParams({ add: undefined });
   };
 
   return (
@@ -132,7 +141,14 @@ export default function IncomeSection({ ingresos, onAdd, colors, autoOpen = fals
               </>
             )}
             <AppButton title="Guardar" color={colors.primary} onPress={handleAdd} />
-            <AppButton title="Cancelar" color={colors.accent} onPress={() => setShowModal(false)} />
+            <AppButton
+              title="Cancelar"
+              color={colors.accent}
+              onPress={() => {
+                setShowModal(false);
+                router.setParams({ add: undefined });
+              }}
+            />
           </View>
         </View>
       </Modal>

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "react-native": "0.79.3",
     "react-native-gesture-handler": "~2.24.0",
     "react-native-reanimated": "~3.17.4",
+    "react-native-svg": "^13.9.0",
+    "react-native-chart-kit": "^6.16.0",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-web": "~0.20.0",


### PR DESCRIPTION
## Summary
- install chart libraries and update README instructions
- implement interactive charts for balance summary
- add ConceptChart component
- provide detail screens for ingresos, deudas, and gastos
- link to new screens from main finance tab

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find global value 'Promise' etc.)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_684466f426cc8331848c7b15865c48eb